### PR TITLE
Deactivatable

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,8 @@ HISTORY of collective.pwexpiry
 0.9 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Update german translations and translate example_validator.
+  [pcdummy]
 
 
 0.8.1 (2015-05-06)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,13 @@ HISTORY of collective.pwexpiry
 0.9 (unreleased)
 ----------------
 
+- Enable the example_validator only when theres a browserlayer.
+  [pcdummy]
+
+- Add a skins layer and remove the confusing > 5 chars message from
+  pwreset_form.
+  [pcdummy]
+
 - Update german translations and translate example_validator.
   [pcdummy]
 

--- a/collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.pt
+++ b/collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.pt
@@ -47,7 +47,7 @@
                   Up to Site Setup
                 </a>
                 
-                <p i18n:translate="description_">
+                <p i18n:translate="description_password_expiration">
                   View and manage user's password expiration properties
                 </p>
 

--- a/collective/pwexpiry/configure.zcml
+++ b/collective/pwexpiry/configure.zcml
@@ -3,6 +3,7 @@
     xmlns:five="http://namespaces.zope.org/five"
     xmlns:i18n="http://namespaces.zope.org/i18n"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    xmlns:cmf="http://namespaces.zope.org/cmf"
     i18n_domain="collective.pwexpiry">
 
   <five:registerPackage package="." initialize=".initialize" />
@@ -12,6 +13,9 @@
 
   <include package=".actions" />
   <include package=".browser" />
+  <include package=".upgrades" />
+
+  <cmf:registerDirectory name="skins" directory="skins" recursive="True" />
 
   <genericsetup:registerProfile
       name="default"

--- a/collective/pwexpiry/example_validator.py
+++ b/collective/pwexpiry/example_validator.py
@@ -1,15 +1,17 @@
 import re
 from AccessControl import AuthEncoding
-from zope.interface import implements
+from zope.interface import implementer
 from Products.CMFCore.utils import getToolByName
 from collective.pwexpiry.interfaces import ICustomPasswordValidator
+from . import _
 
+
+@implementer(ICustomPasswordValidator)
 class ADPasswordValidator(object):
     """
-    Validator for user's passwords fitting default MS Active Directory password policy 
+    Validator for user's passwords fitting default MS Active Directory
+    password policy.
     """
-
-    implements(ICustomPasswordValidator)
 
     def __init__(self, context):
         self.context = context
@@ -19,9 +21,10 @@ class ADPasswordValidator(object):
         Password validation method
         """
 
-        # Checking if minimal length of the entered password is greater than 8 chars
+        # Checking if minimal length of the entered password
+        # is greater than 8 chars
         if len(password) < 8:
-            return u'Passwords must be at least 8 characters in length.'
+            return _(u'Passwords must be at least 8 characters in length.')
 
         if not data:
             # setting password not from the registration form
@@ -43,16 +46,18 @@ class ADPasswordValidator(object):
         # Checking if the entered password doesn't contain
         # the user's username or any parts of his fullname
         password_lower = password.lower()
-        for name in data.get('fullname', '').split(' ') + [data.get('username', ''),]:
+        for name in data.get('fullname', '').split(' ') + \
+                [data.get('username', ''), ]:
             if name and name.lower() in password_lower:
-                return u'Your password cannot contain your account name (Username), '\
-                       u'first name or last name.'
+                return _(u'Your password cannot contain your account name'
+                         u'(Username), first name or last name.')
 
         # Checking if the entered password is different than already set
         # for this existing user
         if data.get('prevhash'):
-            if AuthEncoding.pw_validate(data.get('prevhash'), password.encode('utf-8')):
-                return u'You have to change your password.'
+            if AuthEncoding.pw_validate(data.get('prevhash'),
+                                        password.encode('utf-8')):
+                return _(u'You have to change your password.')
 
         # Checking it the entered password fits to the password policy scheme:
         # it must contain at least 3 from the 4 parts:
@@ -70,10 +75,11 @@ class ADPasswordValidator(object):
         if re.match(r'(?=.*[!$# %])', password):
             matches += 1
         if matches < 3:
-            return u'Passwords must contain at least three of the following '\
-                   u'four character groups: Uppercase characters (A through Z), '\
-                   u'Lowercase characters (a through z), Numerals (0 through 9), '\
-                   u'Special characters such as !, $, #, %'
-            
-        return None
+            return _(u'Passwords must contain at least three of the following '
+                     u'four character groups: '
+                     u'Uppercase characters (A through Z), '
+                     u'Lowercase characters (a through z), '
+                     u'Numerals (0 through 9), '
+                     u'Special characters such as !, $, #, %')
 
+        return None

--- a/collective/pwexpiry/example_validator.py
+++ b/collective/pwexpiry/example_validator.py
@@ -3,7 +3,7 @@ from AccessControl import AuthEncoding
 from zope.interface import implementer
 from Products.CMFCore.utils import getToolByName
 from collective.pwexpiry.interfaces import ICustomPasswordValidator
-from . import _
+from .config import _
 
 
 @implementer(ICustomPasswordValidator)

--- a/collective/pwexpiry/example_validator.py
+++ b/collective/pwexpiry/example_validator.py
@@ -4,6 +4,7 @@ from zope.interface import implementer
 from Products.CMFCore.utils import getToolByName
 from collective.pwexpiry.interfaces import ICustomPasswordValidator
 from .config import _
+from .interfaces import ICollectivePWExpiryLayer
 
 
 @implementer(ICustomPasswordValidator)
@@ -20,6 +21,12 @@ class ADPasswordValidator(object):
         """
         Password validation method
         """
+
+        # Don't check the password if collective.pwexpiry hasn't
+        # been installed yet.
+        if not ICollectivePWExpiryLayer \
+                .providedBy(self.context.REQUEST):
+            return None
 
         # Permit empty passwords here to allow registration links.
         # Plone will force the user to set one.

--- a/collective/pwexpiry/example_validator.py
+++ b/collective/pwexpiry/example_validator.py
@@ -21,6 +21,11 @@ class ADPasswordValidator(object):
         Password validation method
         """
 
+        # Permit empty passwords here to allow registration links.
+        # Plone will force the user to set one.
+        if password is None:
+            return None
+
         # Checking if minimal length of the entered password
         # is greater than 8 chars
         if len(password) < 8:

--- a/collective/pwexpiry/interfaces.py
+++ b/collective/pwexpiry/interfaces.py
@@ -61,3 +61,8 @@ class IUserUnlocked(Interface):
     """
 
     user = Attribute("The user that was unlocked")
+
+
+class ICollectivePWExpiryLayer(Interface):
+    """A layer specific to the collective.pwexpiry package.
+    """

--- a/collective/pwexpiry/locales/collective.pwexpiry.pot
+++ b/collective/pwexpiry/locales/collective.pwexpiry.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-11-05 12:53+0000\n"
+"POT-Creation-Date: 2015-11-05 13:18+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -62,14 +62,14 @@ msgstr ""
 msgid "Your password has expired."
 msgstr ""
 
-#. Default: "View and manage user's password expiration properties"
-#: ../browser/preferences/pwexpirycontrolpanel.pt:50
-msgid "description_"
-msgstr ""
-
 #. Default: "Show all search results"
 #: ../browser/preferences/pwexpirycontrolpanel.pt:157
 msgid "description_pas_show_all_search_results"
+msgstr ""
+
+#. Default: "View and manage user's password expiration properties"
+#: ../browser/preferences/pwexpirycontrolpanel.pt:50
+msgid "description_password_expiration"
 msgstr ""
 
 #. Default: "The date of performing the last notification fot the user"

--- a/collective/pwexpiry/locales/de/LC_MESSAGES/collective.pwexpiry.po
+++ b/collective/pwexpiry/locales/de/LC_MESSAGES/collective.pwexpiry.po
@@ -1,8 +1,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2015-11-05 12:53+0000\n"
-"PO-Revision-Date: 2015-11-05 13:53+0100\n"
+"POT-Creation-Date: 2015-11-05 13:18+0000\n"
+"PO-Revision-Date: 2015-11-05 14:17+0100\n"
 "Last-Translator: Rene Jochum <info@smile4.at>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -18,7 +18,7 @@ msgstr ""
 
 #: ../utils.py:18
 msgid "${days} days left to password expiration"
-msgstr "${days} Tage übrig bis das Passwort abläuft"
+msgstr "Passwort läuft in ${days} Tage ab"
 
 #: ../browser/preferences/pwexpirycontrolpanel.py:111
 msgid "Never"
@@ -30,7 +30,7 @@ msgstr "Keine Benutzer wurde entsperrt"
 
 #: ../profiles/default/controlpanel.xml
 msgid "Password expiration"
-msgstr "Passwort Gültigkeitsdauer"
+msgstr "Passwortablauf"
 
 #: ../example_validator.py:27
 msgid "Passwords must be at least 8 characters in length."
@@ -64,25 +64,25 @@ msgstr "Your password cannot contain your account name(Username), first name or 
 msgid "Your password has expired."
 msgstr "Ihr Passwort ist abgelaufen."
 
-#. Default: "View and manage user's password expiration properties"
-#: ../browser/preferences/pwexpirycontrolpanel.pt:50
-msgid "description_"
-msgstr "Zeige und administriere die Passwortablauf Einstellungen der Benutzer."
-
 #. Default: "Show all search results"
 #: ../browser/preferences/pwexpirycontrolpanel.pt:157
 msgid "description_pas_show_all_search_results"
 msgstr "Zeige alle Suchresultate"
 
+#. Default: "View and manage user's password expiration properties"
+#: ../browser/preferences/pwexpirycontrolpanel.pt:50
+msgid "description_password_expiration"
+msgstr "Zeige und administriere die Passwortablauf Einstellungen der Benutzer."
+
 #. Default: "The date of performing the last notification fot the user"
 #: ../userdataschema.py:31
 msgid "help_last_notification_date"
-msgstr "Das Datum wo der Benutzer das letzte mal Informiert wurde"
+msgstr "Das Datum wo der Benutzer das letzte mal informiert wurde"
 
 #. Default: "The date of setting the password"
 #: ../userdataschema.py:24
 msgid "help_password_date"
-msgstr "Datum wo das Passwort gesetzt wurde"
+msgstr "Datum an dem das Passwort gesetzt wurde"
 
 #. Default: "Apply Changes"
 #: ../browser/preferences/pwexpirycontrolpanel.pt:169
@@ -98,3 +98,4 @@ msgstr "Datum letzte Notifikation"
 #: ../userdataschema.py:23
 msgid "label_password_date"
 msgstr "Passwort Datum"
+

--- a/collective/pwexpiry/locales/de/LC_MESSAGES/collective.pwexpiry.po
+++ b/collective/pwexpiry/locales/de/LC_MESSAGES/collective.pwexpiry.po
@@ -1,99 +1,100 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: \n"
 "POT-Creation-Date: 2015-11-05 12:53+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
+"PO-Revision-Date: 2015-11-05 13:53+0100\n"
+"Last-Translator: Rene Jochum <info@smile4.at>\n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=1; plural=0\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 "Language-Code: en\n"
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
+"Language: de\n"
+"X-Generator: Poedit 1.7.5\n"
 
 #: ../utils.py:18
 msgid "${days} days left to password expiration"
-msgstr ""
+msgstr "${days} Tage übrig bis das Passwort abläuft"
 
 #: ../browser/preferences/pwexpirycontrolpanel.py:111
 msgid "Never"
-msgstr ""
+msgstr "Nie"
 
 #: ../browser/preferences/pwexpirycontrolpanel.py:107
 msgid "No users were unlocked"
-msgstr ""
+msgstr "Keine Benutzer wurde entsperrt"
 
 #: ../profiles/default/controlpanel.xml
 msgid "Password expiration"
-msgstr ""
+msgstr "Passwort Gültigkeitsdauer"
 
 #: ../example_validator.py:27
 msgid "Passwords must be at least 8 characters in length."
-msgstr ""
+msgstr "Passwörter müssen aus mindestens 8 Zeichen bestehen."
 
 #: ../example_validator.py:78
 msgid "Passwords must contain at least three of the following four character groups: Uppercase characters (A through Z), Lowercase characters (a through z), Numerals (0 through 9), Special characters such as !, $, #, %"
-msgstr ""
+msgstr "Passwörter müssen mindestens 3 der folgenden Zeichengruppen enthalten: Großbuchstaben (A - Z), Kleinbuchstaben (a - z), Nummern (0 - 9), Spezial Schriftzeichen wie !, $, #, %<"
 
 #: ../browser/preferences/pwexpirycontrolpanel.py:103
 msgid "The following users were unlocked: %s, "
-msgstr ""
+msgstr "Die folgenden Benutzer wurden entsperrt: %s,"
 
 #: ../browser/preferences/pwexpirycontrolpanel.pt:38
 msgid "User's password expiration panel"
-msgstr ""
+msgstr "Passwortablauf Einstellungen des Benutzers\t"
 
 #: ../example_validator.py:60
 msgid "You have to change your password."
-msgstr ""
+msgstr "Sie müssen Ihr Passwort ändern."
 
 #: ../pwdisable_plugin.py:61
 msgid "Your account has been locked due to too many invalid attempts to login with a wrong password. Your account will remain blocked for the next %s hours. You can reset your password, or contact an administrator to unlock it, using the Contact form."
-msgstr ""
+msgstr "Ihre Konto wurde gesperrt aufgrund von zu vielen ungültigen Anmeldungen. Ihr Konto bleibt gesperrt für die nächsten %s Stunden. Sie können Ihr Passwort zurücksetzen oder einen Administrator über das Kontakt Formular kontaktieren um es zu entsperren."
 
 #: ../example_validator.py:52
 msgid "Your password cannot contain your account name(Username), first name or last name."
-msgstr ""
+msgstr "Your password cannot contain your account name(Username), first name or last name."
 
 #: ../pwexpiry_plugin.py:93
 msgid "Your password has expired."
-msgstr ""
+msgstr "Ihr Passwort ist abgelaufen."
 
 #. Default: "View and manage user's password expiration properties"
 #: ../browser/preferences/pwexpirycontrolpanel.pt:50
 msgid "description_"
-msgstr ""
+msgstr "Zeige und administriere die Passwortablauf Einstellungen der Benutzer."
 
 #. Default: "Show all search results"
 #: ../browser/preferences/pwexpirycontrolpanel.pt:157
 msgid "description_pas_show_all_search_results"
-msgstr ""
+msgstr "Zeige alle Suchresultate"
 
 #. Default: "The date of performing the last notification fot the user"
 #: ../userdataschema.py:31
 msgid "help_last_notification_date"
-msgstr ""
+msgstr "Das Datum wo der Benutzer das letzte mal Informiert wurde"
 
 #. Default: "The date of setting the password"
 #: ../userdataschema.py:24
 msgid "help_password_date"
-msgstr ""
+msgstr "Datum wo das Passwort gesetzt wurde"
 
 #. Default: "Apply Changes"
 #: ../browser/preferences/pwexpirycontrolpanel.pt:169
 msgid "label_apply_changes"
-msgstr ""
+msgstr "Änderungen übernehmen"
 
 #. Default: "Last notification date"
 #: ../userdataschema.py:30
 msgid "label_last_notification_date"
-msgstr ""
+msgstr "Datum letzte Notifikation"
 
 #. Default: "Password date"
 #: ../userdataschema.py:23
 msgid "label_password_date"
-msgstr ""
-
+msgstr "Passwort Datum"

--- a/collective/pwexpiry/locales/en/LC_MESSAGES/collective.pwexpiry.po
+++ b/collective/pwexpiry/locales/en/LC_MESSAGES/collective.pwexpiry.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-04-20 19:59+0000\n"
+"POT-Creation-Date: 2015-11-05 12:53+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,70 +14,86 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./collective/pwexpiry/utils.py:18
+#: ../utils.py:18
 msgid "${days} days left to password expiration"
 msgstr ""
 
-#: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.py:111
+#: ../browser/preferences/pwexpirycontrolpanel.py:111
 msgid "Never"
 msgstr ""
 
-#: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.py:107
+#: ../browser/preferences/pwexpirycontrolpanel.py:107
 msgid "No users were unlocked"
 msgstr ""
 
-#: ./collective/pwexpiry/profiles/default/controlpanel.xml
+#: ../profiles/default/controlpanel.xml
 msgid "Password expiration"
 msgstr ""
 
-#: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.py:103
+#: ../example_validator.py:27
+msgid "Passwords must be at least 8 characters in length."
+msgstr ""
+
+#: ../example_validator.py:78
+msgid "Passwords must contain at least three of the following four character groups: Uppercase characters (A through Z), Lowercase characters (a through z), Numerals (0 through 9), Special characters such as !, $, #, %"
+msgstr ""
+
+#: ../browser/preferences/pwexpirycontrolpanel.py:103
 msgid "The following users were unlocked: %s, "
 msgstr ""
 
-#: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.pt:38
+#: ../browser/preferences/pwexpirycontrolpanel.pt:38
 msgid "User's password expiration panel"
 msgstr ""
 
-#: ./collective/pwexpiry/pwdisable_plugin.py:61
+#: ../example_validator.py:60
+msgid "You have to change your password."
+msgstr ""
+
+#: ../pwdisable_plugin.py:61
 msgid "Your account has been locked due to too many invalid attempts to login with a wrong password. Your account will remain blocked for the next %s hours. You can reset your password, or contact an administrator to unlock it, using the Contact form."
 msgstr ""
 
-#: ./collective/pwexpiry/pwexpiry_plugin.py:93
+#: ../example_validator.py:52
+msgid "Your password cannot contain your account name(Username), first name or last name."
+msgstr ""
+
+#: ../pwexpiry_plugin.py:93
 msgid "Your password has expired."
 msgstr ""
 
 #. Default: "View and manage user's password expiration properties"
-#: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.pt:50
+#: ../browser/preferences/pwexpirycontrolpanel.pt:50
 msgid "description_"
 msgstr ""
 
 #. Default: "Show all search results"
-#: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.pt:157
+#: ../browser/preferences/pwexpirycontrolpanel.pt:157
 msgid "description_pas_show_all_search_results"
 msgstr ""
 
 #. Default: "The date of performing the last notification fot the user"
-#: ./collective/pwexpiry/userdataschema.py:31
+#: ../userdataschema.py:31
 msgid "help_last_notification_date"
 msgstr ""
 
 #. Default: "The date of setting the password"
-#: ./collective/pwexpiry/userdataschema.py:24
+#: ../userdataschema.py:24
 msgid "help_password_date"
 msgstr ""
 
 #. Default: "Apply Changes"
-#: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.pt:169
+#: ../browser/preferences/pwexpirycontrolpanel.pt:169
 msgid "label_apply_changes"
 msgstr ""
 
 #. Default: "Last notification date"
-#: ./collective/pwexpiry/userdataschema.py:30
+#: ../userdataschema.py:30
 msgid "label_last_notification_date"
 msgstr ""
 
 #. Default: "Password date"
-#: ./collective/pwexpiry/userdataschema.py:23
+#: ../userdataschema.py:23
 msgid "label_password_date"
 msgstr ""
 

--- a/collective/pwexpiry/locales/en/LC_MESSAGES/collective.pwexpiry.po
+++ b/collective/pwexpiry/locales/en/LC_MESSAGES/collective.pwexpiry.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-11-05 12:53+0000\n"
+"POT-Creation-Date: 2015-11-05 13:18+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -62,14 +62,14 @@ msgstr ""
 msgid "Your password has expired."
 msgstr ""
 
-#. Default: "View and manage user's password expiration properties"
-#: ../browser/preferences/pwexpirycontrolpanel.pt:50
-msgid "description_"
-msgstr ""
-
 #. Default: "Show all search results"
 #: ../browser/preferences/pwexpirycontrolpanel.pt:157
 msgid "description_pas_show_all_search_results"
+msgstr ""
+
+#. Default: "View and manage user's password expiration properties"
+#: ../browser/preferences/pwexpirycontrolpanel.pt:50
+msgid "description_password_expiration"
 msgstr ""
 
 #. Default: "The date of performing the last notification fot the user"

--- a/collective/pwexpiry/locales/it/LC_MESSAGES/collective.pwexpiry.po
+++ b/collective/pwexpiry/locales/it/LC_MESSAGES/collective.pwexpiry.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2015-04-20 19:59+0000\n"
+"POT-Creation-Date: 2015-11-05 12:53+0000\n"
 "PO-Revision-Date: 2015-04-21 15:53+0000\n"
 "Last-Translator: Giacomo Spettoli <giacomo.spettoli@gmail.com>\n"
 "Language-Team: Plone Italian Translation Discussion <plone-italian-translation-discussion@lists.coactivate.org>\n"
@@ -15,70 +15,86 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: collective.pwexpiry\n"
 
-#: ./collective/pwexpiry/utils.py:18
+#: ../utils.py:18
 msgid "${days} days left to password expiration"
 msgstr "${days} giorni rimasti per la scadenza della password"
 
-#: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.py:111
+#: ../browser/preferences/pwexpirycontrolpanel.py:111
 msgid "Never"
 msgstr "Mai"
 
-#: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.py:107
+#: ../browser/preferences/pwexpirycontrolpanel.py:107
 msgid "No users were unlocked"
 msgstr "Nessun utente è stato sbloccato"
 
-#: ./collective/pwexpiry/profiles/default/controlpanel.xml
+#: ../profiles/default/controlpanel.xml
 msgid "Password expiration"
 msgstr "Scadenza della password"
 
-#: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.py:103
+#: ../example_validator.py:27
+msgid "Passwords must be at least 8 characters in length."
+msgstr ""
+
+#: ../example_validator.py:78
+msgid "Passwords must contain at least three of the following four character groups: Uppercase characters (A through Z), Lowercase characters (a through z), Numerals (0 through 9), Special characters such as !, $, #, %"
+msgstr ""
+
+#: ../browser/preferences/pwexpirycontrolpanel.py:103
 msgid "The following users were unlocked: %s, "
 msgstr "I seguenti utenti sono stati sbloccati: %s"
 
-#: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.pt:38
+#: ../browser/preferences/pwexpirycontrolpanel.pt:38
 msgid "User's password expiration panel"
 msgstr "Pannello della scadenza della password degli utenti"
 
-#: ./collective/pwexpiry/pwdisable_plugin.py:61
+#: ../example_validator.py:60
+msgid "You have to change your password."
+msgstr ""
+
+#: ../pwdisable_plugin.py:61
 msgid "Your account has been locked due to too many invalid attempts to login with a wrong password. Your account will remain blocked for the next %s hours. You can reset your password, or contact an administrator to unlock it, using the Contact form."
 msgstr "Il tuo account è stato bloccato a causa di troppi tentativi falliti di login con una password errata. Il tuo account rimarrà bloccato per le prossime %s ore. Puoi resettare la tua password oppure contattare l'amministratore del sito per sbloccarti, usando i form di contatti."
 
-#: ./collective/pwexpiry/pwexpiry_plugin.py:93
+#: ../example_validator.py:52
+msgid "Your password cannot contain your account name(Username), first name or last name."
+msgstr ""
+
+#: ../pwexpiry_plugin.py:93
 msgid "Your password has expired."
 msgstr "La tua password è scaduta."
 
 #. Default: "View and manage user's password expiration properties"
-#: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.pt:50
+#: ../browser/preferences/pwexpirycontrolpanel.pt:50
 msgid "description_"
 msgstr "Visualizza e gestisci le proprietà di scadenza della password del utente"
 
 #. Default: "Show all search results"
-#: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.pt:157
+#: ../browser/preferences/pwexpirycontrolpanel.pt:157
 msgid "description_pas_show_all_search_results"
 msgstr "Mostra tutti i risultati di ricerca"
 
 #. Default: "The date of performing the last notification fot the user"
-#: ./collective/pwexpiry/userdataschema.py:31
+#: ../userdataschema.py:31
 msgid "help_last_notification_date"
 msgstr "La dell'ultima notifica all'utente"
 
 #. Default: "The date of setting the password"
-#: ./collective/pwexpiry/userdataschema.py:24
+#: ../userdataschema.py:24
 msgid "help_password_date"
 msgstr "La data di impostazione della password"
 
 #. Default: "Apply Changes"
-#: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.pt:169
+#: ../browser/preferences/pwexpirycontrolpanel.pt:169
 msgid "label_apply_changes"
 msgstr "Applica le modifiche"
 
 #. Default: "Last notification date"
-#: ./collective/pwexpiry/userdataschema.py:30
+#: ../userdataschema.py:30
 msgid "label_last_notification_date"
 msgstr "Data di ultima notifica"
 
 #. Default: "Password date"
-#: ./collective/pwexpiry/userdataschema.py:23
+#: ../userdataschema.py:23
 msgid "label_password_date"
 msgstr "Data della password"
 

--- a/collective/pwexpiry/locales/it/LC_MESSAGES/collective.pwexpiry.po
+++ b/collective/pwexpiry/locales/it/LC_MESSAGES/collective.pwexpiry.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2015-11-05 12:53+0000\n"
+"POT-Creation-Date: 2015-11-05 13:18+0000\n"
 "PO-Revision-Date: 2015-04-21 15:53+0000\n"
 "Last-Translator: Giacomo Spettoli <giacomo.spettoli@gmail.com>\n"
 "Language-Team: Plone Italian Translation Discussion <plone-italian-translation-discussion@lists.coactivate.org>\n"
@@ -63,15 +63,15 @@ msgstr ""
 msgid "Your password has expired."
 msgstr "La tua password è scaduta."
 
-#. Default: "View and manage user's password expiration properties"
-#: ../browser/preferences/pwexpirycontrolpanel.pt:50
-msgid "description_"
-msgstr "Visualizza e gestisci le proprietà di scadenza della password del utente"
-
 #. Default: "Show all search results"
 #: ../browser/preferences/pwexpirycontrolpanel.pt:157
 msgid "description_pas_show_all_search_results"
 msgstr "Mostra tutti i risultati di ricerca"
+
+#. Default: "View and manage user's password expiration properties"
+#: ../browser/preferences/pwexpirycontrolpanel.pt:50
+msgid "description_password_expiration"
+msgstr ""
 
 #. Default: "The date of performing the last notification fot the user"
 #: ../userdataschema.py:31

--- a/collective/pwexpiry/locales/update_locales.sh
+++ b/collective/pwexpiry/locales/update_locales.sh
@@ -18,7 +18,7 @@ CURRENT_PATH=`pwd`
 CATALOGNAME="collective.pwexpiry"
 
 # List of languages
-LANGUAGES="en it"
+LANGUAGES="en it de"
 
 # Create locales folder structure for languages
 ROOT_DIR=..

--- a/collective/pwexpiry/patches.py
+++ b/collective/pwexpiry/patches.py
@@ -23,15 +23,16 @@ def extended_testPasswordValidity(self, password, confirm=None, data=None):
     Patching the standard Plone's testPasswordValidity method to
     enable registering a custom password validator.
     """
+    validators = getAdapters((self,), ICustomPasswordValidator)
+    for name, validator in validators:
+        result = validator.validate(password, data)
+        if result:
+            return result
+
     original = original_testPasswordValidity(self, password, confirm)
     if original:
         return original
-    else:
-        validators = getAdapters((self,), ICustomPasswordValidator)
-        for name, validator in validators:
-            result = validator.validate(password, data)
-            if result:
-                return result
+
     return None
 
 RegistrationTool.testPasswordValidity = extended_testPasswordValidity

--- a/collective/pwexpiry/profiles/default/browserlayer.xml
+++ b/collective/pwexpiry/profiles/default/browserlayer.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<layers>
+  <layer
+    name="collective.pwexpiry"
+    interface="collective.pwexpiry.interfaces.ICollectivePWExpiryLayer" />
+</layers>

--- a/collective/pwexpiry/profiles/default/metadata.xml
+++ b/collective/pwexpiry/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-    <version>0001</version>
+    <version>0002</version>
 </metadata>

--- a/collective/pwexpiry/profiles/default/skins.xml
+++ b/collective/pwexpiry/profiles/default/skins.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<object name="portal_skins">
+
+  <object name="pwexpiry"
+      meta_type="Filesystem Directory View"
+      directory="collective.pwexpiry:skins/pwexpiry"/>
+
+  <skin-path name="Sunburst Theme" >
+    <layer name="pwexpiry"
+        insert-after="custom"/>
+  </skin-path>
+
+  <skin-path name="Plone Default" >
+    <layer name="pwexpiry"
+        insert-after="custom"/>
+  </skin-path>
+
+</object>

--- a/collective/pwexpiry/skins/pwexpiry/pwreset_form.cpt
+++ b/collective/pwexpiry/skins/pwexpiry/pwreset_form.cpt
@@ -1,0 +1,119 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-US"
+      lang="en-US"
+      metal:use-macro="here/main_template/macros/master"
+      i18n:domain="plone">
+<body>
+    <metal:main fill-slot="main"
+         tal:define="errors options/state/getErrors">
+
+        <h1 class="documentFirstHeading"
+            i18n:domain="passwordresettool"
+            i18n:translate="heading_reset_password">Set your password</h1>
+
+        <div class="documentDescription" i18n:domain="passwordresettool"
+           i18n:translate="description_reset_password">
+            Please fill out the form below to set your password.
+        </div>
+
+        <div id="content-core">
+            <form class="enableAutoFocus"
+                  name="pwreset_action"
+                  method="post"
+                  tal:attributes="action string:${context/absolute_url}/${template/getId}">
+                <fieldset>
+                    <legend i18n:domain="passwordresettool"
+                            i18n:translate="legend_new_password">New Password</legend>
+
+                    <input type="hidden"
+                           name="randomstring"
+                           value=""
+                           tal:attributes="value options/randomstring | request/randomstring | nothing" />
+
+                    <div class="field"
+                         tal:define="error errors/userid | nothing;
+                                     site_properties context/portal_properties/site_properties;
+                                     use_email_as_login site_properties/use_email_as_login|nothing;"
+                         tal:attributes="class python:test(error, 'field error', 'field')"
+                         tal:condition="here/portal_password_reset/checkUser | nothing">
+
+                      <tal:username tal:condition="not:use_email_as_login">
+                        <label for="userid"
+                               i18n:domain="passwordresettool"
+                               i18n:translate="label_my_user_name_is">My user name is</label>
+                        <div tal:content="error">Validation error output</div>
+
+                        <div class="formHelp"
+                             i18n:domain="passwordresettool"
+                             i18n:translate="help_userid">
+                            Enter your user name for verification.
+                        </div>
+                      </tal:username>
+                      <tal:email tal:condition="use_email_as_login">
+                        <label for="userid"
+                               i18n:domain="passwordresettool"
+                               i18n:translate="label_my_email_address_is">My email address is</label>
+                        <div tal:content="error">Validation error output</div>
+
+                        <div class="formHelp"
+                             i18n:domain="passwordresettool"
+                             i18n:translate="help_verify_email">
+                            Enter your email address for verification.
+                        </div>
+                      </tal:email>
+
+                        <input name="userid" id="userid" />
+                    </div>
+
+                    <div class="field"
+                         tal:define="error errors/password | nothing;"
+                         tal:attributes="class python:test(error, 'field error', 'field')">
+
+                        <label for="password"
+                               i18n:translate="label_new_password">New password</label>
+                        <div tal:content="error">Validation error output</div>
+
+                        <input type="password"
+                               id="password"
+                               name="password"
+                               size="10" />
+                    </div>
+
+                    <div class="field"
+                         tal:define="error errors/password | nothing;"
+                         tal:attributes="class python:test(error, 'field error', 'field')">
+
+                        <label for="password2"
+                               i18n:translate="label_confirm_password">Confirm password</label>
+                        <div tal:content="error">Validation error output</div>
+
+                        <div class="formHelp"
+                             i18n:translate="help_confirm_password">
+                            Re-enter the password. Make sure the passwords are identical.
+                        </div>
+
+                        <input type="password"
+                               id="password2"
+                               name="password2"
+                               size="10"
+                               />
+                    </div>
+
+                    <div>
+                        <div class="label">&nbsp;</div>
+
+                        <div class="field">
+                            <input class="context"
+                                   type="submit"
+                                   value="Set my password"
+                                   i18n:domain="passwordresettool"
+                                   i18n:attributes="value"
+                                   />
+                        </div>
+                    </div>
+                    <input type="hidden" name="form.submitted" value="1" />
+                </fieldset>
+            </form>
+        </div>
+    </metal:main>
+</body>
+</html>

--- a/collective/pwexpiry/skins/pwexpiry/pwreset_form.cpt.metadata
+++ b/collective/pwexpiry/skins/pwexpiry/pwreset_form.cpt.metadata
@@ -1,0 +1,7 @@
+[validators]
+validators = validate_pwreset_userid, validate_pwreset_password
+
+[actions]
+action.success = traverse_to:string:pwreset_action
+action.invalid = traverse_to:string:pwreset_invalid
+action.expired = traverse_to:string:pwreset_expired

--- a/collective/pwexpiry/upgrades/configure.zcml
+++ b/collective/pwexpiry/upgrades/configure.zcml
@@ -1,0 +1,28 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:five="http://namespaces.zope.org/five"
+    xmlns:i18n="http://namespaces.zope.org/i18n"
+    xmlns:gs="http://namespaces.zope.org/genericsetup"
+    i18n_domain="collective.pwexpiry">
+
+  <gs:registerProfile
+      name="0001_to_0002"
+      title="Add a browserlayer"
+      directory="profiles/0001_to_0002"
+      description=""
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      for="Products.CMFPlone.interfaces.IMigratingPloneSiteRoot"
+      />
+
+  <gs:upgradeSteps
+      source="0001"
+      destination="0002"
+      profile="collective.pwexpiry:default">
+
+    <gs:upgradeDepends
+        title="Add a browserlayer, register skins"
+        import_profile="collective.pwexpiry.upgrades:0001_to_0002"
+        run_deps="True"/>
+
+  </gs:upgradeSteps>
+</configure>

--- a/collective/pwexpiry/upgrades/profiles/0001_to_0002/browserlayer.xml
+++ b/collective/pwexpiry/upgrades/profiles/0001_to_0002/browserlayer.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<layers>
+  <layer
+    name="collective.pwexpiry"
+    interface="collective.pwexpiry.interfaces.ICollectivePWExpiryLayer" />
+</layers>

--- a/collective/pwexpiry/upgrades/profiles/0001_to_0002/skins.xml
+++ b/collective/pwexpiry/upgrades/profiles/0001_to_0002/skins.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<object name="portal_skins">
+
+  <object name="pwexpiry"
+      meta_type="Filesystem Directory View"
+      directory="collective.pwexpiry:skins/pwexpiry"/>
+
+  <skin-path name="Sunburst Theme" >
+    <layer name="pwexpiry"
+        insert-after="custom"/>
+  </skin-path>
+
+  <skin-path name="Plone Default" >
+    <layer name="pwexpiry"
+        insert-after="custom"/>
+  </skin-path>
+
+</object>


### PR DESCRIPTION
Please merge `german_translations` first, this branch is on top of that one.

This branch adds a browserlayer via an upgradestep which allows integrators to activate/deactivate the example_validator.

Also it fixes pwreset_form by removing the confusing ">5 chars pw" line.
