### PR TITLE
install the notify_and_expire script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,4 +49,7 @@ setup(name='collective.pwexpiry',
       [z3c.autoinclude.plugin]
       target = plone
       """,
+      scripts=[
+          'collective/pwexpiry/scripts/notify_and_expire.py',
+      ]
       )


### PR DESCRIPTION
This gives users a more reliable path to use when scheduling the nightly run.

You’d also need to add something like this to `buildout.cfg`:

```
[collective.pwexpiry]
recipe = zc.recipe.egg:scripts
scripts = notify_and_expire.py=notify_and_expire
```
