### PR TITLE
fix a `KeyError` in the unlock process

### DIFF
--- a/collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.py
+++ b/collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.py
@@ -86,7 +86,7 @@ class PwExpiryControlPanel(UsersOverviewControlPanel):
 
             unlocked = list()
             for user in users:
-                if user['unlock']:
+                if user.get('unlock'):
                     member = mtool.getMemberById(user.id)
 
                     member.setMemberProperties(


### PR DESCRIPTION
Maybe this depends on your browser, but if the “Unlock” box is unchecked for one or more users when submitting the form from the control panel, the request omits the value completely.

With the box checked:

```
PDB++> self.request['users']
[{'id': 'timmy', 'unlock': '1'}]
```

With the box unchecked:

```
PDB++> self.request['users']
[{'id': 'timmy'}]
```

So you can’t test the value because it’s not there. Using `.get()` should make it behave correctly in all cases.
