### PR TITLE
Add a javascript to fix popups with expired users.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,9 @@ HISTORY of collective.pwexpiry
 0.9 (unreleased)
 ----------------
 
+- Show status message "your account has expired" in login popup.
+  [pcdummy]
+
 - Update german translations.
   [pcdummy]
 

--- a/collective/pwexpiry/browser/configure.zcml
+++ b/collective/pwexpiry/browser/configure.zcml
@@ -1,10 +1,17 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
     xmlns:five="http://namespaces.zope.org/five"
+    xmlns:browser="http://namespaces.zope.org/browser"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
     i18n_domain="collective.pwexpiry">
 
   <include package=".emails" />
   <include package=".preferences" />
+
+  <browser:resource
+      name="collective.pwexpiry.fix_login_popup.js"
+      file="js/fix_login_popup.js"
+      layer="..interfaces.ICollectivePWExpiryLayer"
+      />
 
 </configure>

--- a/collective/pwexpiry/browser/js/fix_login_popup.js
+++ b/collective/pwexpiry/browser/js/fix_login_popup.js
@@ -1,0 +1,38 @@
+jQuery(function($){
+
+    if (msieversion() > 0 && msieversion() < 7) {
+        // it's not realistic to think we can deal with all the bugs
+        // of IE 6 and lower. Fortunately, all this is just progressive
+        // enhancement.
+        return;
+    }
+
+    // First remove the original registration.
+    pb.remove_overlay($('#portal-personaltools a[href$="/login"], #portal-personaltools a[href$="/login_form"], .discussion a[href$="/login"], .discussion a[href$="/login_form"]'));
+
+    // And reregister with 'form[name="mail_password"]' in it.
+    // login form (based on plone's default registration - also handles mail_password form to show warning for expired passwords.
+    $('#portal-personaltools a[href$="/login"], #portal-personaltools a[href$="/login_form"], .discussion a[href$="/login"], .discussion a[href$="/login_form"]').prepOverlay(
+        {
+            subtype: 'ajax',
+            filter: common_content_filter,
+            formselector: 'form#login_form, form[name="mail_password"]',
+            cssclass: 'overlay-login',
+            noform: function () {
+                if (location.href.search(/pwreset_finish$/) >= 0) {
+                    return 'redirect';
+                } else {
+                    return 'reload';
+                }
+            },
+            redirect: function () {
+                var href = location.href;
+                if (href.search(/pwreset_finish$/) >= 0) {
+                    return href.slice(0, href.length-14) + 'logged_in';
+                } else {
+                    return href;
+                }
+            }
+        }
+    );
+});

--- a/collective/pwexpiry/profiles/default/jsregistry.xml
+++ b/collective/pwexpiry/profiles/default/jsregistry.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<object name="portal_javascripts">
+  <javascript id="++resource++collective.pwexpiry.fix_login_popup.js"
+    cacheable="True" compression="safe" cookable="True" enabled="True"
+    bundle="default" inline="False"
+    insert-after="popupforms.js" />
+</object>

--- a/collective/pwexpiry/profiles/default/metadata.xml
+++ b/collective/pwexpiry/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-    <version>0002</version>
+    <version>0003</version>
 </metadata>

--- a/collective/pwexpiry/pwexpiry_plugin.py
+++ b/collective/pwexpiry/pwexpiry_plugin.py
@@ -96,7 +96,7 @@ class PwExpiryPlugin(BasePlugin):
         if user_expired:
             portal_url = api.portal.get_tool(name='portal_url')()
             IStatusMessage(request).add(
-                _(u'Your password has expired.'), type='warning'
+                _(u'Your password has expired.'), type='error'
             )
             response.redirect(
                 '%s/mail_password_form?userid=%s' % (portal_url, user_expired),

--- a/collective/pwexpiry/upgrades/configure.zcml
+++ b/collective/pwexpiry/upgrades/configure.zcml
@@ -25,4 +25,25 @@
         run_deps="True"/>
 
   </gs:upgradeSteps>
+
+  <gs:registerProfile
+      name="0002_to_0003"
+      title="Show status message 'your account has expired' in login popup."
+      directory="profiles/0002_to_0003"
+      description=""
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      for="Products.CMFPlone.interfaces.IMigratingPloneSiteRoot"
+      />
+
+  <gs:upgradeSteps
+      source="0002"
+      destination="0003"
+      profile="collective.pwexpiry:default">
+
+    <gs:upgradeDepends
+        title="Show status message 'your account has expired' in login popup."
+        import_profile="collective.pwexpiry.upgrades:0002_to_0003"
+        run_deps="True"/>
+
+  </gs:upgradeSteps>
 </configure>

--- a/collective/pwexpiry/upgrades/profiles/0002_to_0003/jsregistry.xml
+++ b/collective/pwexpiry/upgrades/profiles/0002_to_0003/jsregistry.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<object name="portal_javascripts">
+  <javascript id="++resource++collective.pwexpiry.fix_login_popup.js"
+    cacheable="True" compression="safe" cookable="True" enabled="True"
+    bundle="default" inline="False"
+    insert-after="popupforms.js" />
+</object>


### PR DESCRIPTION
The following commit fixes the login popup with expired messages.

Before this PR expired messages did not show to the user as he got redirected before the message was shown.

Now the popup shows "mail_password_form" with the status message.

Signed-off-by: Rene Jochum rene@jochums.at
