### PR TITLE
Use semantic versioning

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-1.0.0 (unreleased)
+1.0b1 (unreleased)
 ------------------
 
 - Update i18n and add Brazilian Portuguese and Spanish translations.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import os
 def read(*rnames):
     return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
 
-version = '1.0.0.dev0'
+version = '1.0b1.dev0'
 
 setup(name='collective.pwexpiry',
       version=version,
@@ -13,6 +13,7 @@ setup(name='collective.pwexpiry',
                   in Plone",
       long_description=read("README.rst") + "\n" + read("CHANGES.rst"),
       classifiers=[
+          'Development Status :: 4 - Beta',
           "Programming Language :: Python",
           "Programming Language :: Python :: 2.7",
           "Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION
The package is compatible with Plone 4.3 again; I fixed a couple of issues and added translations.

I think it's better to use semantic versioning for now on; if you agree, please merge this pull request and make a new release as I have a customer waiting for this feature.

IMO, as the package lacks tests, naming this new version 1.0b1 is fine.