### PR TITLE
Standarize messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,9 @@ install:
 - bin/buildout
 before_script:
 - export DISPLAY=:99.0
+- export ROBOT_SELENIUM2LIBRARY_RUN_ON_FAILURE="Capture Page Screenshot"
 - sh -e /etc/init.d/xvfb start
+- firefox -v
 script:
 - bin/test
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
   directories:
   - eggs
 addons:
-  firefox: 63.0.3
+  firefox: 46.0.1
 env:
 - PLONE_VERSION=4.3
 - PLONE_VERSION=5.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ sudo: false
 cache:
   directories:
   - eggs
+addons:
+  firefox: 63.0.3
 env:
 - PLONE_VERSION=4.3
 - PLONE_VERSION=5.0

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,6 +1,6 @@
 [buildout]
 extends =
-    https://raw.github.com/collective/buildout.plonetest/master/test-5.1.x.cfg
+    test-5.1.x.cfg
 
 newest = false
 package-name = collective.pwexpiry
@@ -40,24 +40,3 @@ mode = 755
 recipe = zc.recipe.egg
 eggs = zest.releaser[recommended]
 
-[versions]
-setuptools = 40.5.0
-zc.buildout = 2.12.2
-zest.releaser = 6.15.2
-Products.PrintingMailHost = 1.1.0
-bleach = 3.0.2
-chardet = 3.0.4
-check-manifest = 0.35
-idna = 2.6
-pkginfo = 1.4.2
-pyroma = 2.4
-readme-renderer = 24.0
-requests-toolbelt = 0.8.0
-
-# Required by:
-# zest.releaser==6.15.2
-colorama = 0.3.7
-
-# Required by:
-# bleach==3.0.2
-webencodings = 0.5.1

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -13,6 +13,7 @@ parts +=
     scripts
     rebuild_i18n-sh
     releaser
+    robot
 
 [instance]
 eggs +=
@@ -40,3 +41,9 @@ mode = 755
 recipe = zc.recipe.egg
 eggs = zest.releaser[recommended]
 
+[robot]
+recipe = zc.recipe.egg
+eggs =
+    Pillow
+    ${test:eggs}
+    plone.app.robotframework

--- a/collective/pwexpiry/__init__.py
+++ b/collective/pwexpiry/__init__.py
@@ -1,4 +1,5 @@
 from AccessControl.Permissions import add_user_folders
+from AccessControl import allow_module
 from Products.PluggableAuthService.PluggableAuthService import \
     registerMultiPlugin
 import pwexpiry_plugin
@@ -7,6 +8,8 @@ import pwdisable_plugin
 
 def initialize(context):
     """Initializer called when used as a Zope 2 product."""
+
+    allow_module('collective.pwexpiry.config')
 
     registerMultiPlugin(pwexpiry_plugin.PwExpiryPlugin.meta_type)
     context.registerClass(

--- a/collective/pwexpiry/locales/collective.pwexpiry.pot
+++ b/collective/pwexpiry/locales/collective.pwexpiry.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-11-07 18:36+0000\n"
+"POT-Creation-Date: 2018-11-15 21:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,6 +18,26 @@ msgstr ""
 msgid "Adds the feature of password expiration control."
 msgstr ""
 
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:67
+msgid "Email address not known."
+msgstr ""
+
+#: ./collective/pwexpiry/pwdisable_plugin.py:64
+#: ./collective/pwexpiry/skins/pwexpiry/logged_in.cpy:26
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:81
+msgid "Login failed. Both email address and password are case sensitive, check that caps lock is not enabled. If you have entered your password correctly, your account might be locked."
+msgstr ""
+
+#: ./collective/pwexpiry/pwdisable_plugin.py:72
+#: ./collective/pwexpiry/skins/pwexpiry/logged_in.cpy:33
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:88
+msgid "Login failed. Both login name and password are case sensitive, check that caps lock is not enabled. If you have entered your password correctly, your account might be locked."
+msgstr ""
+
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:72
+msgid "Login name not found."
+msgstr ""
+
 #: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.py:134
 msgid "Never"
 msgstr ""
@@ -30,12 +50,28 @@ msgstr ""
 msgid "Password expiration"
 msgstr ""
 
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:77
+msgid "Password incorrect."
+msgstr ""
+
 #: ./collective/pwexpiry/example_validator.py:41
 msgid "Passwords must be at least 8 characters in length."
 msgstr ""
 
 #: ./collective/pwexpiry/example_validator.py:98
 msgid "Passwords must contain at least three of the following four character groups: Uppercase characters (A through Z), Lowercase characters (a through z), Numerals (0 through 9), Special characters such as !, $, #, %"
+msgstr ""
+
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:48
+msgid "Please enter your email address."
+msgstr ""
+
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:53
+msgid "Please enter your login name."
+msgstr ""
+
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:58
+msgid "Please enter your password."
 msgstr ""
 
 #: ./collective/pwexpiry/configure.zcml:37
@@ -58,8 +94,8 @@ msgstr ""
 msgid "You have to change your password."
 msgstr ""
 
-#: ./collective/pwexpiry/pwdisable_plugin.py:58
-msgid "Your account has been locked due to too many invalid attempts to login with a wrong password. Your account will remain blocked for the next ${hrs} hours. You can reset your password, or contact an administrator to unlock it, using the Contact form."
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:22
+msgid "You must enable cookies before you can log in."
 msgstr ""
 
 #: ./collective/pwexpiry/example_validator.py:72

--- a/collective/pwexpiry/locales/collective.pwexpiry.pot
+++ b/collective/pwexpiry/locales/collective.pwexpiry.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-11-16 14:09+0000\n"
+"POT-Creation-Date: 2018-11-20 14:25+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,24 +18,16 @@ msgstr ""
 msgid "Adds the feature of password expiration control."
 msgstr ""
 
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:67
-msgid "Email address not known."
-msgstr ""
-
 #: ./collective/pwexpiry/pwdisable_plugin.py:64
 #: ./collective/pwexpiry/skins/pwexpiry/logged_in.cpy:26
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:81
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:82
 msgid "Login failed. Both email address and password are case sensitive, check that caps lock is not enabled. If you have entered your password correctly, your account might be locked. You can reset your password, or contact an administrator to unlock it, using the Contact form."
 msgstr ""
 
 #: ./collective/pwexpiry/pwdisable_plugin.py:73
 #: ./collective/pwexpiry/skins/pwexpiry/logged_in.cpy:34
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:89
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:90
 msgid "Login failed. Both login name and password are case sensitive, check that caps lock is not enabled. If you have entered your password correctly, your account might be locked. You can reset your password, or contact an administrator to unlock it, using the Contact form."
-msgstr ""
-
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:72
-msgid "Login name not found."
 msgstr ""
 
 #: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.py:134
@@ -50,28 +42,12 @@ msgstr ""
 msgid "Password expiration"
 msgstr ""
 
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:77
-msgid "Password incorrect."
-msgstr ""
-
 #: ./collective/pwexpiry/example_validator.py:41
 msgid "Passwords must be at least 8 characters in length."
 msgstr ""
 
 #: ./collective/pwexpiry/example_validator.py:98
 msgid "Passwords must contain at least three of the following four character groups: Uppercase characters (A through Z), Lowercase characters (a through z), Numerals (0 through 9), Special characters such as !, $, #, %"
-msgstr ""
-
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:48
-msgid "Please enter your email address."
-msgstr ""
-
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:53
-msgid "Please enter your login name."
-msgstr ""
-
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:58
-msgid "Please enter your password."
 msgstr ""
 
 #: ./collective/pwexpiry/configure.zcml:37
@@ -92,10 +68,6 @@ msgstr ""
 
 #: ./collective/pwexpiry/example_validator.py:80
 msgid "You have to change your password."
-msgstr ""
-
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:22
-msgid "You must enable cookies before you can log in."
 msgstr ""
 
 #: ./collective/pwexpiry/example_validator.py:72

--- a/collective/pwexpiry/locales/collective.pwexpiry.pot
+++ b/collective/pwexpiry/locales/collective.pwexpiry.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-11-15 21:09+0000\n"
+"POT-Creation-Date: 2018-11-16 14:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -25,13 +25,13 @@ msgstr ""
 #: ./collective/pwexpiry/pwdisable_plugin.py:64
 #: ./collective/pwexpiry/skins/pwexpiry/logged_in.cpy:26
 #: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:81
-msgid "Login failed. Both email address and password are case sensitive, check that caps lock is not enabled. If you have entered your password correctly, your account might be locked."
+msgid "Login failed. Both email address and password are case sensitive, check that caps lock is not enabled. If you have entered your password correctly, your account might be locked. You can reset your password, or contact an administrator to unlock it, using the Contact form."
 msgstr ""
 
-#: ./collective/pwexpiry/pwdisable_plugin.py:72
-#: ./collective/pwexpiry/skins/pwexpiry/logged_in.cpy:33
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:88
-msgid "Login failed. Both login name and password are case sensitive, check that caps lock is not enabled. If you have entered your password correctly, your account might be locked."
+#: ./collective/pwexpiry/pwdisable_plugin.py:73
+#: ./collective/pwexpiry/skins/pwexpiry/logged_in.cpy:34
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:89
+msgid "Login failed. Both login name and password are case sensitive, check that caps lock is not enabled. If you have entered your password correctly, your account might be locked. You can reset your password, or contact an administrator to unlock it, using the Contact form."
 msgstr ""
 
 #: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:72

--- a/collective/pwexpiry/locales/de/LC_MESSAGES/collective.pwexpiry.po
+++ b/collective/pwexpiry/locales/de/LC_MESSAGES/collective.pwexpiry.po
@@ -4,9 +4,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "POT-Creation-Date: 2018-11-15 21:09+0000\n"
-"PO-Revision-Date: 2018-11-15 18:29-0300\n"
-"Last-Translator: Franco Pellegrini <franco.pellegrini@enfoldsystems.com>\n"
-"Language-Team: German <kde-i18n-doc@kde.org>\n"
+"PO-Revision-Date: 2018-11-15 23:17+0100\n"
+"Last-Translator: Harald Frießnegger <harald@webmeisterei.com>\n"
+"Language-Team: German <kde-i18n-de@kde.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -29,7 +29,6 @@ msgid "Email address not known."
 msgstr "E-Mail-Adresse unbekannt"
 
 #: ./collective/pwexpiry/pwdisable_plugin.py:64
-#, fuzzy
 #: ./collective/pwexpiry/skins/pwexpiry/logged_in.cpy:26
 #: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:81
 msgid ""
@@ -38,11 +37,11 @@ msgid ""
 " account might be locked."
 msgstr ""
 "Anmeldung fehlgeschlagen. Sowohl bei der E-Mail-Adresse als auch beim"
-" Passwort wird Groß- und Kleinschreibung berücksichtigt. Stellen Sie sicher,"
-" dass die Feststelltaste nicht eingerastet ist."
+" Passwort wird zwischen Groß- und Kleinschreibung unterschieden. Stellen Sie"
+" sicher, dass die Feststelltaste nicht eingerastet ist. Wenn Sie ihr Passwort"
+" korrekt eingegeben haben könnte ihr Konto gesperrt sein."
 
 #: ./collective/pwexpiry/pwdisable_plugin.py:72
-#, fuzzy
 #: ./collective/pwexpiry/skins/pwexpiry/logged_in.cpy:33
 #: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:88
 msgid ""
@@ -52,7 +51,8 @@ msgid ""
 msgstr ""
 "Anmeldung fehlgeschlagen. Sowohl bei Benutzername als auch beim Passwort wird"
 " zwischen Groß- und Kleinschreibung unterschieden. Stellen Sie sicher, dass"
-" die Feststelltaste nicht aktiviert ist."
+" die Feststelltaste nicht eingerastet ist. Wenn Sie ihr Passwort korrekt"
+" eingegeben haben könnte ihr Konto gesperrt sein."
 
 #: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:72
 msgid "Login name not found."
@@ -175,7 +175,6 @@ msgstr "Ihr Passwort läuft in ${days} Tagen ab"
 
 #. Default: "Hello ${fullname},\n\nThere are ${days} days left before your password expires!\n\nPlease ensure to reset your password before it's expired."
 #: ./collective/pwexpiry/browser/emails/emails.py:51
-#, fuzzy
 msgid "email_text"
 msgstr ""
 "Hallo ${username},\n"

--- a/collective/pwexpiry/locales/de/LC_MESSAGES/collective.pwexpiry.po
+++ b/collective/pwexpiry/locales/de/LC_MESSAGES/collective.pwexpiry.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2018-11-15 21:09+0000\n"
+"POT-Creation-Date: 2018-11-16 14:09+0000\n"
 "PO-Revision-Date: 2018-11-15 23:17+0100\n"
 "Last-Translator: Harald Frießnegger <harald@webmeisterei.com>\n"
 "Language-Team: German <kde-i18n-de@kde.org>\n"
@@ -20,43 +20,27 @@ msgstr ""
 
 #: ./collective/pwexpiry/configure.zcml:29
 msgid "Adds the feature of password expiration control."
-msgstr ""
-"Ermöglicht es Passworte ablaufen zu lassen und Qualitätskriterien von"
-" Passworten zu prüfen."
+msgstr "Ermöglicht es Passworte ablaufen zu lassen und Qualitätskriterien von Passworten zu prüfen."
 
 #: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:67
 msgid "Email address not known."
-msgstr "E-Mail-Adresse unbekannt"
+msgstr ""
 
 #: ./collective/pwexpiry/pwdisable_plugin.py:64
 #: ./collective/pwexpiry/skins/pwexpiry/logged_in.cpy:26
 #: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:81
-msgid ""
-"Login failed. Both email address and password are case sensitive, check that"
-" caps lock is not enabled. If you have entered your password correctly, your"
-" account might be locked."
+msgid "Login failed. Both email address and password are case sensitive, check that caps lock is not enabled. If you have entered your password correctly, your account might be locked. You can reset your password, or contact an administrator to unlock it, using the Contact form."
 msgstr ""
-"Anmeldung fehlgeschlagen. Sowohl bei der E-Mail-Adresse als auch beim"
-" Passwort wird zwischen Groß- und Kleinschreibung unterschieden. Stellen Sie"
-" sicher, dass die Feststelltaste nicht eingerastet ist. Wenn Sie ihr Passwort"
-" korrekt eingegeben haben könnte ihr Konto gesperrt sein."
 
-#: ./collective/pwexpiry/pwdisable_plugin.py:72
-#: ./collective/pwexpiry/skins/pwexpiry/logged_in.cpy:33
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:88
-msgid ""
-"Login failed. Both login name and password are case sensitive, check that"
-" caps lock is not enabled. If you have entered your password correctly, your"
-" account might be locked."
+#: ./collective/pwexpiry/pwdisable_plugin.py:73
+#: ./collective/pwexpiry/skins/pwexpiry/logged_in.cpy:34
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:89
+msgid "Login failed. Both login name and password are case sensitive, check that caps lock is not enabled. If you have entered your password correctly, your account might be locked. You can reset your password, or contact an administrator to unlock it, using the Contact form."
 msgstr ""
-"Anmeldung fehlgeschlagen. Sowohl bei Benutzername als auch beim Passwort wird"
-" zwischen Groß- und Kleinschreibung unterschieden. Stellen Sie sicher, dass"
-" die Feststelltaste nicht eingerastet ist. Wenn Sie ihr Passwort korrekt"
-" eingegeben haben könnte ihr Konto gesperrt sein."
 
 #: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:72
 msgid "Login name not found."
-msgstr "Benutzername wurde nicht gefunden."
+msgstr ""
 
 #: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.py:134
 msgid "Never"
@@ -72,38 +56,30 @@ msgstr "Passwortablauf"
 
 #: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:77
 msgid "Password incorrect."
-msgstr "Passwort ist falsch."
+msgstr ""
 
 #: ./collective/pwexpiry/example_validator.py:41
 msgid "Passwords must be at least 8 characters in length."
 msgstr "Passwörter müssen aus mindestens 8 Zeichen bestehen."
 
 #: ./collective/pwexpiry/example_validator.py:98
-msgid ""
-"Passwords must contain at least three of the following four character groups:"
-" Uppercase characters (A through Z), Lowercase characters (a through z),"
-" Numerals (0 through 9), Special characters such as !, $, #, %"
-msgstr ""
-"Passwörter müssen mindestens 3 der folgenden Zeichengruppen enthalten:"
-" Großbuchstaben (A - Z), Kleinbuchstaben (a - z), Nummern (0 - 9), Spezial"
-" Schriftzeichen wie !, $, #, %"
+msgid "Passwords must contain at least three of the following four character groups: Uppercase characters (A through Z), Lowercase characters (a through z), Numerals (0 through 9), Special characters such as !, $, #, %"
+msgstr "Passwörter müssen mindestens 3 der folgenden Zeichengruppen enthalten: Großbuchstaben (A - Z), Kleinbuchstaben (a - z), Nummern (0 - 9), Spezial Schriftzeichen wie !, $, #, %"
 
 #: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:48
 msgid "Please enter your email address."
-msgstr "Bitte tragen Sie Ihre E-Mail-Adresse ein."
+msgstr ""
 
 #: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:53
 msgid "Please enter your login name."
-msgstr "Bitte geben Sie Ihren Benutzernamen ein."
+msgstr ""
 
 #: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:58
 msgid "Please enter your password."
-msgstr "Bitte geben Sie Ihr Passwort ein."
+msgstr ""
 
 #: ./collective/pwexpiry/configure.zcml:37
-msgid ""
-"Profile intended only in Plone 4 (No need to manually run it, default install"
-" profile should do it)."
+msgid "Profile intended only in Plone 4 (No need to manually run it, default install profile should do it)."
 msgstr ""
 
 #: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.py:126
@@ -124,15 +100,11 @@ msgstr "Sie müssen Ihr Passwort ändern."
 
 #: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:22
 msgid "You must enable cookies before you can log in."
-msgstr "Sie müssen Cookies erlauben, bevor Sie sich anmelden können."
+msgstr ""
 
 #: ./collective/pwexpiry/example_validator.py:72
-msgid ""
-"Your password cannot contain your account name(Username), first name or last"
-" name."
-msgstr ""
-"Ihr Passwort darf weder ihren Benutzer- noch ihren Nach- oder Vornamen"
-" enthalten."
+msgid "Your password cannot contain your account name(Username), first name or last name."
+msgstr "Ihr Passwort darf weder ihren Benutzer- noch ihren Nach- oder Vornamen enthalten."
 
 #: ./collective/pwexpiry/pwexpiry_plugin.py:106
 msgid "Your password has expired."
@@ -240,8 +212,7 @@ msgid "reset_password_email_text"
 msgstr ""
 "\n"
 "\n"
-"Um Ihr Passwort zurückzusetzen, rufen Sie bitte"
-" ${server_url}/mail_password_form?userid=${username} auf"
+"Um Ihr Passwort zurückzusetzen, rufen Sie bitte ${server_url}/mail_password_form?userid=${username} auf"
 
 #. Default: "\n\nThis email was sent from ${server_name}"
 #: ./collective/pwexpiry/browser/emails/emails.py:92
@@ -250,5 +221,3 @@ msgstr ""
 "\n"
 "\n"
 "Diese Email wurde von ${server_name} versendet."
-
-

--- a/collective/pwexpiry/locales/de/LC_MESSAGES/collective.pwexpiry.po
+++ b/collective/pwexpiry/locales/de/LC_MESSAGES/collective.pwexpiry.po
@@ -1,11 +1,12 @@
 # Harald Friessnegger <harald@webmeisterei.com>, 2016, 2018.
+# Franco Pellegrini <franco.pellegrini@enfoldsystems.com>, 2018.
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2018-11-07 18:36+0000\n"
-"PO-Revision-Date: 2018-05-25 08:54+0100\n"
-"Last-Translator: Harald Frießnegger <harald@webmeisterei.com>\n"
-"Language-Team: German <kde-i18n-de@kde.org>\n"
+"POT-Creation-Date: 2018-11-15 21:09+0000\n"
+"PO-Revision-Date: 2018-11-15 18:29-0300\n"
+"Last-Translator: Franco Pellegrini <franco.pellegrini@enfoldsystems.com>\n"
+"Language-Team: German <kde-i18n-doc@kde.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -19,7 +20,43 @@ msgstr ""
 
 #: ./collective/pwexpiry/configure.zcml:29
 msgid "Adds the feature of password expiration control."
-msgstr "Ermöglicht es Passworte ablaufen zu lassen und Qualitätskriterien von Passworten zu prüfen."
+msgstr ""
+"Ermöglicht es Passworte ablaufen zu lassen und Qualitätskriterien von"
+" Passworten zu prüfen."
+
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:67
+msgid "Email address not known."
+msgstr "E-Mail-Adresse unbekannt"
+
+#: ./collective/pwexpiry/pwdisable_plugin.py:64
+#, fuzzy
+#: ./collective/pwexpiry/skins/pwexpiry/logged_in.cpy:26
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:81
+msgid ""
+"Login failed. Both email address and password are case sensitive, check that"
+" caps lock is not enabled. If you have entered your password correctly, your"
+" account might be locked."
+msgstr ""
+"Anmeldung fehlgeschlagen. Sowohl bei der E-Mail-Adresse als auch beim"
+" Passwort wird Groß- und Kleinschreibung berücksichtigt. Stellen Sie sicher,"
+" dass die Feststelltaste nicht eingerastet ist."
+
+#: ./collective/pwexpiry/pwdisable_plugin.py:72
+#, fuzzy
+#: ./collective/pwexpiry/skins/pwexpiry/logged_in.cpy:33
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:88
+msgid ""
+"Login failed. Both login name and password are case sensitive, check that"
+" caps lock is not enabled. If you have entered your password correctly, your"
+" account might be locked."
+msgstr ""
+"Anmeldung fehlgeschlagen. Sowohl bei Benutzername als auch beim Passwort wird"
+" zwischen Groß- und Kleinschreibung unterschieden. Stellen Sie sicher, dass"
+" die Feststelltaste nicht aktiviert ist."
+
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:72
+msgid "Login name not found."
+msgstr "Benutzername wurde nicht gefunden."
 
 #: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.py:134
 msgid "Never"
@@ -33,16 +70,40 @@ msgstr "Keine Benutzer wurden entsperrt"
 msgid "Password expiration"
 msgstr "Passwortablauf"
 
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:77
+msgid "Password incorrect."
+msgstr "Passwort ist falsch."
+
 #: ./collective/pwexpiry/example_validator.py:41
 msgid "Passwords must be at least 8 characters in length."
 msgstr "Passwörter müssen aus mindestens 8 Zeichen bestehen."
 
 #: ./collective/pwexpiry/example_validator.py:98
-msgid "Passwords must contain at least three of the following four character groups: Uppercase characters (A through Z), Lowercase characters (a through z), Numerals (0 through 9), Special characters such as !, $, #, %"
-msgstr "Passwörter müssen mindestens 3 der folgenden Zeichengruppen enthalten: Großbuchstaben (A - Z), Kleinbuchstaben (a - z), Nummern (0 - 9), Spezial Schriftzeichen wie !, $, #, %"
+msgid ""
+"Passwords must contain at least three of the following four character groups:"
+" Uppercase characters (A through Z), Lowercase characters (a through z),"
+" Numerals (0 through 9), Special characters such as !, $, #, %"
+msgstr ""
+"Passwörter müssen mindestens 3 der folgenden Zeichengruppen enthalten:"
+" Großbuchstaben (A - Z), Kleinbuchstaben (a - z), Nummern (0 - 9), Spezial"
+" Schriftzeichen wie !, $, #, %"
+
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:48
+msgid "Please enter your email address."
+msgstr "Bitte tragen Sie Ihre E-Mail-Adresse ein."
+
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:53
+msgid "Please enter your login name."
+msgstr "Bitte geben Sie Ihren Benutzernamen ein."
+
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:58
+msgid "Please enter your password."
+msgstr "Bitte geben Sie Ihr Passwort ein."
 
 #: ./collective/pwexpiry/configure.zcml:37
-msgid "Profile intended only in Plone 4 (No need to manually run it, default install profile should do it)."
+msgid ""
+"Profile intended only in Plone 4 (No need to manually run it, default install"
+" profile should do it)."
 msgstr ""
 
 #: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.py:126
@@ -61,13 +122,17 @@ msgstr "Passwortablauf Einstellungen des Benutzers\t"
 msgid "You have to change your password."
 msgstr "Sie müssen Ihr Passwort ändern."
 
-#: ./collective/pwexpiry/pwdisable_plugin.py:58
-msgid "Your account has been locked due to too many invalid attempts to login with a wrong password. Your account will remain blocked for the next ${hrs} hours. You can reset your password, or contact an administrator to unlock it, using the Contact form."
-msgstr "Ihr Konto wurde aufgrund von zu vielen ungültigen Anmeldungen für die nächsten ${hrs} Stunden gesperrt. Sie können Ihr Passwort zurücksetzen oder einen Administrator über das Kontakt Formular bitten es zu entsperren."
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:22
+msgid "You must enable cookies before you can log in."
+msgstr "Sie müssen Cookies erlauben, bevor Sie sich anmelden können."
 
 #: ./collective/pwexpiry/example_validator.py:72
-msgid "Your password cannot contain your account name(Username), first name or last name."
-msgstr "Ihr Passwort darf weder ihren Benutzer- noch ihren Nach- oder Vornamen enthalten."
+msgid ""
+"Your password cannot contain your account name(Username), first name or last"
+" name."
+msgstr ""
+"Ihr Passwort darf weder ihren Benutzer- noch ihren Nach- oder Vornamen"
+" enthalten."
 
 #: ./collective/pwexpiry/pwexpiry_plugin.py:106
 msgid "Your password has expired."
@@ -176,7 +241,8 @@ msgid "reset_password_email_text"
 msgstr ""
 "\n"
 "\n"
-"Um Ihr Passwort zurückzusetzen, rufen Sie bitte ${server_url}/mail_password_form?userid=${username} auf"
+"Um Ihr Passwort zurückzusetzen, rufen Sie bitte"
+" ${server_url}/mail_password_form?userid=${username} auf"
 
 #. Default: "\n\nThis email was sent from ${server_name}"
 #: ./collective/pwexpiry/browser/emails/emails.py:92
@@ -185,3 +251,5 @@ msgstr ""
 "\n"
 "\n"
 "Diese Email wurde von ${server_name} versendet."
+
+

--- a/collective/pwexpiry/locales/de/LC_MESSAGES/collective.pwexpiry.po
+++ b/collective/pwexpiry/locales/de/LC_MESSAGES/collective.pwexpiry.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2018-11-16 14:09+0000\n"
+"POT-Creation-Date: 2018-11-20 14:25+0000\n"
 "PO-Revision-Date: 2018-11-19 22:14+0100\n"
 "Last-Translator: Harald Frießnegger <harald@webmeisterei.com>\n"
 "Language-Team: German <kde-i18n-de@kde.org>\n"
@@ -20,49 +20,19 @@ msgstr ""
 
 #: ./collective/pwexpiry/configure.zcml:29
 msgid "Adds the feature of password expiration control."
-msgstr ""
-"Ermöglicht es Passworte ablaufen zu lassen und Qualitätskriterien von"
-" Passworten zu prüfen."
-
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:67
-msgid "Email address not known."
-msgstr ""
+msgstr "Ermöglicht es Passworte ablaufen zu lassen und Qualitätskriterien von Passworten zu prüfen."
 
 #: ./collective/pwexpiry/pwdisable_plugin.py:64
 #: ./collective/pwexpiry/skins/pwexpiry/logged_in.cpy:26
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:81
-msgid ""
-"Login failed. Both email address and password are case sensitive, check that"
-" caps lock is not enabled. If you have entered your password correctly, your"
-" account might be locked. You can reset your password, or contact an"
-" administrator to unlock it, using the Contact form."
-msgstr ""
-"Anmeldung fehlgeschlagen. Sowohl bei der E-Mail-Adresse als auch beim"
-" Passwort wird Groß- und Kleinschreibung berücksichtigt. Stellen Sie sicher,"
-" dass die Feststelltaste nicht eingerastet ist.Wenn Sie ihr Passwort korrekt"
-" eingegeben haben könnte ihr Konto gesperrt sein. Sie können Ihr Passwort"
-" zurücksetzen oder einen Administrator über das Kontakt Formular bitten es zu"
-" entsperren."
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:82
+msgid "Login failed. Both email address and password are case sensitive, check that caps lock is not enabled. If you have entered your password correctly, your account might be locked. You can reset your password, or contact an administrator to unlock it, using the Contact form."
+msgstr "Anmeldung fehlgeschlagen. Sowohl bei der E-Mail-Adresse als auch beim Passwort wird Groß- und Kleinschreibung berücksichtigt. Stellen Sie sicher, dass die Feststelltaste nicht eingerastet ist.Wenn Sie ihr Passwort korrekt eingegeben haben könnte ihr Konto gesperrt sein. Sie können Ihr Passwort zurücksetzen oder einen Administrator über das Kontakt Formular bitten es zu entsperren."
 
 #: ./collective/pwexpiry/pwdisable_plugin.py:73
 #: ./collective/pwexpiry/skins/pwexpiry/logged_in.cpy:34
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:89
-msgid ""
-"Login failed. Both login name and password are case sensitive, check that"
-" caps lock is not enabled. If you have entered your password correctly, your"
-" account might be locked. You can reset your password, or contact an"
-" administrator to unlock it, using the Contact form."
-msgstr ""
-"Anmeldung fehlgeschlagen. Sowohl bei Benutzername als auch beim Passwort wird"
-" Groß- und Kleinschreibung berücksichtigt. Stellen Sie sicher, dass die"
-" Feststelltaste nicht eingerastet ist.Wenn Sie ihr Passwort korrekt"
-" eingegeben haben könnte ihr Konto gesperrt sein. Sie können Ihr Passwort"
-" zurücksetzen oder einen Administrator über das Kontakt Formular bitten es zu"
-" entsperren."
-
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:72
-msgid "Login name not found."
-msgstr ""
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:90
+msgid "Login failed. Both login name and password are case sensitive, check that caps lock is not enabled. If you have entered your password correctly, your account might be locked. You can reset your password, or contact an administrator to unlock it, using the Contact form."
+msgstr "Anmeldung fehlgeschlagen. Sowohl bei Benutzername als auch beim Passwort wird Groß- und Kleinschreibung berücksichtigt. Stellen Sie sicher, dass die Feststelltaste nicht eingerastet ist.Wenn Sie ihr Passwort korrekt eingegeben haben könnte ihr Konto gesperrt sein. Sie können Ihr Passwort zurücksetzen oder einen Administrator über das Kontakt Formular bitten es zu entsperren."
 
 #: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.py:134
 msgid "Never"
@@ -76,40 +46,16 @@ msgstr "Keine Benutzer wurden entsperrt"
 msgid "Password expiration"
 msgstr "Passwortablauf"
 
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:77
-msgid "Password incorrect."
-msgstr ""
-
 #: ./collective/pwexpiry/example_validator.py:41
 msgid "Passwords must be at least 8 characters in length."
 msgstr "Passwörter müssen aus mindestens 8 Zeichen bestehen."
 
 #: ./collective/pwexpiry/example_validator.py:98
-msgid ""
-"Passwords must contain at least three of the following four character groups:"
-" Uppercase characters (A through Z), Lowercase characters (a through z),"
-" Numerals (0 through 9), Special characters such as !, $, #, %"
-msgstr ""
-"Passwörter müssen mindestens 3 der folgenden Zeichengruppen enthalten:"
-" Großbuchstaben (A - Z), Kleinbuchstaben (a - z), Nummern (0 - 9), Spezial"
-" Schriftzeichen wie !, $, #, %"
-
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:48
-msgid "Please enter your email address."
-msgstr ""
-
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:53
-msgid "Please enter your login name."
-msgstr ""
-
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:58
-msgid "Please enter your password."
-msgstr ""
+msgid "Passwords must contain at least three of the following four character groups: Uppercase characters (A through Z), Lowercase characters (a through z), Numerals (0 through 9), Special characters such as !, $, #, %"
+msgstr "Passwörter müssen mindestens 3 der folgenden Zeichengruppen enthalten: Großbuchstaben (A - Z), Kleinbuchstaben (a - z), Nummern (0 - 9), Spezial Schriftzeichen wie !, $, #, %"
 
 #: ./collective/pwexpiry/configure.zcml:37
-msgid ""
-"Profile intended only in Plone 4 (No need to manually run it, default install"
-" profile should do it)."
+msgid "Profile intended only in Plone 4 (No need to manually run it, default install profile should do it)."
 msgstr ""
 
 #: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.py:126
@@ -128,17 +74,9 @@ msgstr "Passwortablauf Einstellungen des Benutzers\t"
 msgid "You have to change your password."
 msgstr "Sie müssen Ihr Passwort ändern."
 
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:22
-msgid "You must enable cookies before you can log in."
-msgstr ""
-
 #: ./collective/pwexpiry/example_validator.py:72
-msgid ""
-"Your password cannot contain your account name(Username), first name or last"
-" name."
-msgstr ""
-"Ihr Passwort darf weder ihren Benutzer- noch ihren Nach- oder Vornamen"
-" enthalten."
+msgid "Your password cannot contain your account name(Username), first name or last name."
+msgstr "Ihr Passwort darf weder ihren Benutzer- noch ihren Nach- oder Vornamen enthalten."
 
 #: ./collective/pwexpiry/pwexpiry_plugin.py:106
 msgid "Your password has expired."
@@ -246,8 +184,7 @@ msgid "reset_password_email_text"
 msgstr ""
 "\n"
 "\n"
-"Um Ihr Passwort zurückzusetzen, rufen Sie bitte"
-" ${server_url}/mail_password_form?userid=${username} auf"
+"Um Ihr Passwort zurückzusetzen, rufen Sie bitte ${server_url}/mail_password_form?userid=${username} auf"
 
 #. Default: "\n\nThis email was sent from ${server_name}"
 #: ./collective/pwexpiry/browser/emails/emails.py:92
@@ -256,4 +193,3 @@ msgstr ""
 "\n"
 "\n"
 "Diese Email wurde von ${server_name} versendet."
-

--- a/collective/pwexpiry/locales/de/LC_MESSAGES/collective.pwexpiry.po
+++ b/collective/pwexpiry/locales/de/LC_MESSAGES/collective.pwexpiry.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "POT-Creation-Date: 2018-11-16 14:09+0000\n"
-"PO-Revision-Date: 2018-11-15 23:17+0100\n"
+"PO-Revision-Date: 2018-11-19 22:14+0100\n"
 "Last-Translator: Harald Frießnegger <harald@webmeisterei.com>\n"
 "Language-Team: German <kde-i18n-de@kde.org>\n"
 "MIME-Version: 1.0\n"
@@ -20,7 +20,9 @@ msgstr ""
 
 #: ./collective/pwexpiry/configure.zcml:29
 msgid "Adds the feature of password expiration control."
-msgstr "Ermöglicht es Passworte ablaufen zu lassen und Qualitätskriterien von Passworten zu prüfen."
+msgstr ""
+"Ermöglicht es Passworte ablaufen zu lassen und Qualitätskriterien von"
+" Passworten zu prüfen."
 
 #: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:67
 msgid "Email address not known."
@@ -29,14 +31,34 @@ msgstr ""
 #: ./collective/pwexpiry/pwdisable_plugin.py:64
 #: ./collective/pwexpiry/skins/pwexpiry/logged_in.cpy:26
 #: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:81
-msgid "Login failed. Both email address and password are case sensitive, check that caps lock is not enabled. If you have entered your password correctly, your account might be locked. You can reset your password, or contact an administrator to unlock it, using the Contact form."
+msgid ""
+"Login failed. Both email address and password are case sensitive, check that"
+" caps lock is not enabled. If you have entered your password correctly, your"
+" account might be locked. You can reset your password, or contact an"
+" administrator to unlock it, using the Contact form."
 msgstr ""
+"Anmeldung fehlgeschlagen. Sowohl bei der E-Mail-Adresse als auch beim"
+" Passwort wird Groß- und Kleinschreibung berücksichtigt. Stellen Sie sicher,"
+" dass die Feststelltaste nicht eingerastet ist.Wenn Sie ihr Passwort korrekt"
+" eingegeben haben könnte ihr Konto gesperrt sein. Sie können Ihr Passwort"
+" zurücksetzen oder einen Administrator über das Kontakt Formular bitten es zu"
+" entsperren."
 
 #: ./collective/pwexpiry/pwdisable_plugin.py:73
 #: ./collective/pwexpiry/skins/pwexpiry/logged_in.cpy:34
 #: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:89
-msgid "Login failed. Both login name and password are case sensitive, check that caps lock is not enabled. If you have entered your password correctly, your account might be locked. You can reset your password, or contact an administrator to unlock it, using the Contact form."
+msgid ""
+"Login failed. Both login name and password are case sensitive, check that"
+" caps lock is not enabled. If you have entered your password correctly, your"
+" account might be locked. You can reset your password, or contact an"
+" administrator to unlock it, using the Contact form."
 msgstr ""
+"Anmeldung fehlgeschlagen. Sowohl bei Benutzername als auch beim Passwort wird"
+" Groß- und Kleinschreibung berücksichtigt. Stellen Sie sicher, dass die"
+" Feststelltaste nicht eingerastet ist.Wenn Sie ihr Passwort korrekt"
+" eingegeben haben könnte ihr Konto gesperrt sein. Sie können Ihr Passwort"
+" zurücksetzen oder einen Administrator über das Kontakt Formular bitten es zu"
+" entsperren."
 
 #: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:72
 msgid "Login name not found."
@@ -63,8 +85,14 @@ msgid "Passwords must be at least 8 characters in length."
 msgstr "Passwörter müssen aus mindestens 8 Zeichen bestehen."
 
 #: ./collective/pwexpiry/example_validator.py:98
-msgid "Passwords must contain at least three of the following four character groups: Uppercase characters (A through Z), Lowercase characters (a through z), Numerals (0 through 9), Special characters such as !, $, #, %"
-msgstr "Passwörter müssen mindestens 3 der folgenden Zeichengruppen enthalten: Großbuchstaben (A - Z), Kleinbuchstaben (a - z), Nummern (0 - 9), Spezial Schriftzeichen wie !, $, #, %"
+msgid ""
+"Passwords must contain at least three of the following four character groups:"
+" Uppercase characters (A through Z), Lowercase characters (a through z),"
+" Numerals (0 through 9), Special characters such as !, $, #, %"
+msgstr ""
+"Passwörter müssen mindestens 3 der folgenden Zeichengruppen enthalten:"
+" Großbuchstaben (A - Z), Kleinbuchstaben (a - z), Nummern (0 - 9), Spezial"
+" Schriftzeichen wie !, $, #, %"
 
 #: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:48
 msgid "Please enter your email address."
@@ -79,7 +107,9 @@ msgid "Please enter your password."
 msgstr ""
 
 #: ./collective/pwexpiry/configure.zcml:37
-msgid "Profile intended only in Plone 4 (No need to manually run it, default install profile should do it)."
+msgid ""
+"Profile intended only in Plone 4 (No need to manually run it, default install"
+" profile should do it)."
 msgstr ""
 
 #: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.py:126
@@ -103,8 +133,12 @@ msgid "You must enable cookies before you can log in."
 msgstr ""
 
 #: ./collective/pwexpiry/example_validator.py:72
-msgid "Your password cannot contain your account name(Username), first name or last name."
-msgstr "Ihr Passwort darf weder ihren Benutzer- noch ihren Nach- oder Vornamen enthalten."
+msgid ""
+"Your password cannot contain your account name(Username), first name or last"
+" name."
+msgstr ""
+"Ihr Passwort darf weder ihren Benutzer- noch ihren Nach- oder Vornamen"
+" enthalten."
 
 #: ./collective/pwexpiry/pwexpiry_plugin.py:106
 msgid "Your password has expired."
@@ -212,7 +246,8 @@ msgid "reset_password_email_text"
 msgstr ""
 "\n"
 "\n"
-"Um Ihr Passwort zurückzusetzen, rufen Sie bitte ${server_url}/mail_password_form?userid=${username} auf"
+"Um Ihr Passwort zurückzusetzen, rufen Sie bitte"
+" ${server_url}/mail_password_form?userid=${username} auf"
 
 #. Default: "\n\nThis email was sent from ${server_name}"
 #: ./collective/pwexpiry/browser/emails/emails.py:92
@@ -221,3 +256,4 @@ msgstr ""
 "\n"
 "\n"
 "Diese Email wurde von ${server_name} versendet."
+

--- a/collective/pwexpiry/locales/en/LC_MESSAGES/collective.pwexpiry.po
+++ b/collective/pwexpiry/locales/en/LC_MESSAGES/collective.pwexpiry.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-11-07 18:36+0000\n"
+"POT-Creation-Date: 2018-11-15 21:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,6 +18,26 @@ msgstr ""
 msgid "Adds the feature of password expiration control."
 msgstr ""
 
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:67
+msgid "Email address not known."
+msgstr ""
+
+#: ./collective/pwexpiry/pwdisable_plugin.py:64
+#: ./collective/pwexpiry/skins/pwexpiry/logged_in.cpy:26
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:81
+msgid "Login failed. Both email address and password are case sensitive, check that caps lock is not enabled. If you have entered your password correctly, your account might be locked."
+msgstr ""
+
+#: ./collective/pwexpiry/pwdisable_plugin.py:72
+#: ./collective/pwexpiry/skins/pwexpiry/logged_in.cpy:33
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:88
+msgid "Login failed. Both login name and password are case sensitive, check that caps lock is not enabled. If you have entered your password correctly, your account might be locked."
+msgstr ""
+
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:72
+msgid "Login name not found."
+msgstr ""
+
 #: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.py:134
 msgid "Never"
 msgstr ""
@@ -30,12 +50,28 @@ msgstr ""
 msgid "Password expiration"
 msgstr ""
 
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:77
+msgid "Password incorrect."
+msgstr ""
+
 #: ./collective/pwexpiry/example_validator.py:41
 msgid "Passwords must be at least 8 characters in length."
 msgstr ""
 
 #: ./collective/pwexpiry/example_validator.py:98
 msgid "Passwords must contain at least three of the following four character groups: Uppercase characters (A through Z), Lowercase characters (a through z), Numerals (0 through 9), Special characters such as !, $, #, %"
+msgstr ""
+
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:48
+msgid "Please enter your email address."
+msgstr ""
+
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:53
+msgid "Please enter your login name."
+msgstr ""
+
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:58
+msgid "Please enter your password."
 msgstr ""
 
 #: ./collective/pwexpiry/configure.zcml:37
@@ -58,8 +94,8 @@ msgstr ""
 msgid "You have to change your password."
 msgstr ""
 
-#: ./collective/pwexpiry/pwdisable_plugin.py:58
-msgid "Your account has been locked due to too many invalid attempts to login with a wrong password. Your account will remain blocked for the next ${hrs} hours. You can reset your password, or contact an administrator to unlock it, using the Contact form."
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:22
+msgid "You must enable cookies before you can log in."
 msgstr ""
 
 #: ./collective/pwexpiry/example_validator.py:72

--- a/collective/pwexpiry/locales/en/LC_MESSAGES/collective.pwexpiry.po
+++ b/collective/pwexpiry/locales/en/LC_MESSAGES/collective.pwexpiry.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-11-16 14:09+0000\n"
+"POT-Creation-Date: 2018-11-20 14:25+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,24 +18,16 @@ msgstr ""
 msgid "Adds the feature of password expiration control."
 msgstr ""
 
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:67
-msgid "Email address not known."
-msgstr ""
-
 #: ./collective/pwexpiry/pwdisable_plugin.py:64
 #: ./collective/pwexpiry/skins/pwexpiry/logged_in.cpy:26
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:81
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:82
 msgid "Login failed. Both email address and password are case sensitive, check that caps lock is not enabled. If you have entered your password correctly, your account might be locked. You can reset your password, or contact an administrator to unlock it, using the Contact form."
 msgstr ""
 
 #: ./collective/pwexpiry/pwdisable_plugin.py:73
 #: ./collective/pwexpiry/skins/pwexpiry/logged_in.cpy:34
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:89
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:90
 msgid "Login failed. Both login name and password are case sensitive, check that caps lock is not enabled. If you have entered your password correctly, your account might be locked. You can reset your password, or contact an administrator to unlock it, using the Contact form."
-msgstr ""
-
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:72
-msgid "Login name not found."
 msgstr ""
 
 #: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.py:134
@@ -50,28 +42,12 @@ msgstr ""
 msgid "Password expiration"
 msgstr ""
 
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:77
-msgid "Password incorrect."
-msgstr ""
-
 #: ./collective/pwexpiry/example_validator.py:41
 msgid "Passwords must be at least 8 characters in length."
 msgstr ""
 
 #: ./collective/pwexpiry/example_validator.py:98
 msgid "Passwords must contain at least three of the following four character groups: Uppercase characters (A through Z), Lowercase characters (a through z), Numerals (0 through 9), Special characters such as !, $, #, %"
-msgstr ""
-
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:48
-msgid "Please enter your email address."
-msgstr ""
-
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:53
-msgid "Please enter your login name."
-msgstr ""
-
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:58
-msgid "Please enter your password."
 msgstr ""
 
 #: ./collective/pwexpiry/configure.zcml:37
@@ -92,10 +68,6 @@ msgstr ""
 
 #: ./collective/pwexpiry/example_validator.py:80
 msgid "You have to change your password."
-msgstr ""
-
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:22
-msgid "You must enable cookies before you can log in."
 msgstr ""
 
 #: ./collective/pwexpiry/example_validator.py:72

--- a/collective/pwexpiry/locales/en/LC_MESSAGES/collective.pwexpiry.po
+++ b/collective/pwexpiry/locales/en/LC_MESSAGES/collective.pwexpiry.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-11-15 21:09+0000\n"
+"POT-Creation-Date: 2018-11-16 14:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -25,13 +25,13 @@ msgstr ""
 #: ./collective/pwexpiry/pwdisable_plugin.py:64
 #: ./collective/pwexpiry/skins/pwexpiry/logged_in.cpy:26
 #: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:81
-msgid "Login failed. Both email address and password are case sensitive, check that caps lock is not enabled. If you have entered your password correctly, your account might be locked."
+msgid "Login failed. Both email address and password are case sensitive, check that caps lock is not enabled. If you have entered your password correctly, your account might be locked. You can reset your password, or contact an administrator to unlock it, using the Contact form."
 msgstr ""
 
-#: ./collective/pwexpiry/pwdisable_plugin.py:72
-#: ./collective/pwexpiry/skins/pwexpiry/logged_in.cpy:33
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:88
-msgid "Login failed. Both login name and password are case sensitive, check that caps lock is not enabled. If you have entered your password correctly, your account might be locked."
+#: ./collective/pwexpiry/pwdisable_plugin.py:73
+#: ./collective/pwexpiry/skins/pwexpiry/logged_in.cpy:34
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:89
+msgid "Login failed. Both login name and password are case sensitive, check that caps lock is not enabled. If you have entered your password correctly, your account might be locked. You can reset your password, or contact an administrator to unlock it, using the Contact form."
 msgstr ""
 
 #: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:72

--- a/collective/pwexpiry/locales/es/LC_MESSAGES/collective.pwexpiry.po
+++ b/collective/pwexpiry/locales/es/LC_MESSAGES/collective.pwexpiry.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2018-11-16 14:09+0000\n"
+"POT-Creation-Date: 2018-11-20 14:25+0000\n"
 "PO-Revision-Date: 2018-11-15 18:28-0300\n"
 "Last-Translator: Franco Pellegrini <franco.pellegrini@enfoldsystems.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -21,24 +21,16 @@ msgstr ""
 msgid "Adds the feature of password expiration control."
 msgstr "Adiciona control de expiración de contraseñas."
 
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:67
-msgid "Email address not known."
-msgstr ""
-
 #: ./collective/pwexpiry/pwdisable_plugin.py:64
 #: ./collective/pwexpiry/skins/pwexpiry/logged_in.cpy:26
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:81
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:82
 msgid "Login failed. Both email address and password are case sensitive, check that caps lock is not enabled. If you have entered your password correctly, your account might be locked. You can reset your password, or contact an administrator to unlock it, using the Contact form."
 msgstr ""
 
 #: ./collective/pwexpiry/pwdisable_plugin.py:73
 #: ./collective/pwexpiry/skins/pwexpiry/logged_in.cpy:34
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:89
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:90
 msgid "Login failed. Both login name and password are case sensitive, check that caps lock is not enabled. If you have entered your password correctly, your account might be locked. You can reset your password, or contact an administrator to unlock it, using the Contact form."
-msgstr ""
-
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:72
-msgid "Login name not found."
 msgstr ""
 
 #: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.py:134
@@ -53,10 +45,6 @@ msgstr "No existen usuarios bloqueados"
 msgid "Password expiration"
 msgstr "Expiración de contraseña"
 
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:77
-msgid "Password incorrect."
-msgstr ""
-
 #: ./collective/pwexpiry/example_validator.py:41
 msgid "Passwords must be at least 8 characters in length."
 msgstr "Las contraseñas deben tener por lo menos 8 caracteres."
@@ -64,18 +52,6 @@ msgstr "Las contraseñas deben tener por lo menos 8 caracteres."
 #: ./collective/pwexpiry/example_validator.py:98
 msgid "Passwords must contain at least three of the following four character groups: Uppercase characters (A through Z), Lowercase characters (a through z), Numerals (0 through 9), Special characters such as !, $, #, %"
 msgstr "Las contraseñas deben contener al menos 3 de los siguientes 4 grupos de caracteres: letras mayúsculas (A-Z), letras minúsculas (a-z), números (0-9) y caracteres especiales como !, $, #, %."
-
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:48
-msgid "Please enter your email address."
-msgstr ""
-
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:53
-msgid "Please enter your login name."
-msgstr ""
-
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:58
-msgid "Please enter your password."
-msgstr ""
 
 #: ./collective/pwexpiry/configure.zcml:37
 msgid "Profile intended only in Plone 4 (No need to manually run it, default install profile should do it)."
@@ -96,10 +72,6 @@ msgstr "Panel de expiración de contraseñas del usuario"
 #: ./collective/pwexpiry/example_validator.py:80
 msgid "You have to change your password."
 msgstr "Usted tiene que modificar su contraseña."
-
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:22
-msgid "You must enable cookies before you can log in."
-msgstr ""
 
 #: ./collective/pwexpiry/example_validator.py:72
 msgid "Your password cannot contain your account name(Username), first name or last name."

--- a/collective/pwexpiry/locales/es/LC_MESSAGES/collective.pwexpiry.po
+++ b/collective/pwexpiry/locales/es/LC_MESSAGES/collective.pwexpiry.po
@@ -1,12 +1,13 @@
+# Franco Pellegrini <franco.pellegrini@enfoldsystems.com>, 2018.
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2018-11-07 18:36+0000\n"
-"PO-Revision-Date: 2018-11-07 16:39-0200\n"
-"Last-Translator: \n"
-"Language-Team: \n"
+"POT-Creation-Date: 2018-11-15 21:09+0000\n"
+"PO-Revision-Date: 2018-11-15 18:28-0300\n"
+"Last-Translator: Franco Pellegrini <franco.pellegrini@enfoldsystems.com>\n"
+"Language-Team: English <kde-i18n-doc@kde.org>\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "Language-Code: en\n"
@@ -14,98 +15,163 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 "Language: es\n"
-"X-Generator: Poedit 1.8.7.1\n"
+"X-Generator: Lokalize 2.0\n"
 
-#: collective/pwexpiry/configure.zcml:29
+#: ./collective/pwexpiry/configure.zcml:29
 msgid "Adds the feature of password expiration control."
 msgstr "Adiciona control de expiración de contraseñas."
 
-#: collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.py:134
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:67
+msgid "Email address not known."
+msgstr "Dirección de correo desconocida."
+
+#: ./collective/pwexpiry/pwdisable_plugin.py:64
+#: ./collective/pwexpiry/skins/pwexpiry/logged_in.cpy:26
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:81
+msgid ""
+"Login failed. Both email address and password are case sensitive, check that"
+" caps lock is not enabled. If you have entered your password correctly, your"
+" account might be locked."
+msgstr ""
+"Error en el inicio de sesión. Tanto la dirección del correo como la"
+" contraseña son sensibles a la capitalización, comprueba que la tecla Bloq"
+" Mayús no está activa. Si ha introducido su contraseña de manera correcta, es"
+" posible que su cuenta se encuentre bloqueada."
+
+#: ./collective/pwexpiry/pwdisable_plugin.py:72
+#: ./collective/pwexpiry/skins/pwexpiry/logged_in.cpy:33
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:88
+msgid ""
+"Login failed. Both login name and password are case sensitive, check that"
+" caps lock is not enabled. If you have entered your password correctly, your"
+" account might be locked."
+msgstr ""
+"Error en el inicio de sesión. Tanto el nombre de inicio de sesión como la"
+" contraseña son sensibles a la capitalización, comprueba que la tecla de"
+" bloqueo de mayúsculas no está habilitada. Si ha introducido su contraseña de"
+" manera correcta, es posible que su cuenta se encuentre bloqueada."
+
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:72
+msgid "Login name not found."
+msgstr "Nombre de inicio de sesión no encontrado."
+
+#: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.py:134
 msgid "Never"
 msgstr "Nunca"
 
-#: collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.py:130
+#: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.py:130
 msgid "No users were unlocked"
 msgstr "No existen usuarios bloqueados"
 
-#: collective/pwexpiry/profiles/default/controlpanel.xml
+#: ./collective/pwexpiry/profiles/default/controlpanel.xml
 msgid "Password expiration"
 msgstr "Expiración de contraseña"
 
-#: collective/pwexpiry/example_validator.py:41
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:77
+msgid "Password incorrect."
+msgstr "Contraseña incorrecta."
+
+#: ./collective/pwexpiry/example_validator.py:41
 msgid "Passwords must be at least 8 characters in length."
 msgstr "Las contraseñas deben tener por lo menos 8 caracteres."
 
-#: collective/pwexpiry/example_validator.py:98
-msgid "Passwords must contain at least three of the following four character groups: Uppercase characters (A through Z), Lowercase characters (a through z), Numerals (0 through 9), Special characters such as !, $, #, %"
-msgstr "Las contraseñas deben contener al menos 3 de los siguientes 4 grupos de caracteres: letras mayúsculas (A-Z), letras minúsculas (a-z), números (0-9) y caracteres especiales como !, $, #, %."
+#: ./collective/pwexpiry/example_validator.py:98
+msgid ""
+"Passwords must contain at least three of the following four character groups:"
+" Uppercase characters (A through Z), Lowercase characters (a through z),"
+" Numerals (0 through 9), Special characters such as !, $, #, %"
+msgstr ""
+"Las contraseñas deben contener al menos 3 de los siguientes 4 grupos de"
+" caracteres: letras mayúsculas (A-Z), letras minúsculas (a-z), números (0-9)"
+" y caracteres especiales como !, $, #, %."
 
-#: collective/pwexpiry/configure.zcml:37
-msgid "Profile intended only in Plone 4 (No need to manually run it, default install profile should do it)."
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:48
+msgid "Please enter your email address."
+msgstr "Por favor, introduzca su dirección de correo."
+
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:53
+msgid "Please enter your login name."
+msgstr "Por favor, introduzca su nombre de inicio de sesión."
+
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:58
+msgid "Please enter your password."
+msgstr "Por favor, introduzca su contraseña."
+
+#: ./collective/pwexpiry/configure.zcml:37
+msgid ""
+"Profile intended only in Plone 4 (No need to manually run it, default install"
+" profile should do it)."
 msgstr ""
 
-#: collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.py:126
+#: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.py:126
 msgid "The following users were unlocked: %s, "
 msgstr "Los siguientes usuarios fueron desbloqueados: %s, "
 
-#: collective/pwexpiry/configure.zcml:45
+#: ./collective/pwexpiry/configure.zcml:45
 msgid "Uninstalls collective.pwexpiry."
 msgstr "Desinstala collective.pwexpiry."
 
-#: collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.pt:38
+#: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.pt:38
 msgid "User's password expiration panel"
 msgstr "Panel de expiración de contraseñas del usuario"
 
-#: collective/pwexpiry/example_validator.py:80
+#: ./collective/pwexpiry/example_validator.py:80
 msgid "You have to change your password."
 msgstr "Usted tiene que modificar su contraseña."
 
-#: collective/pwexpiry/pwdisable_plugin.py:58
-msgid "Your account has been locked due to too many invalid attempts to login with a wrong password. Your account will remain blocked for the next ${hrs} hours. You can reset your password, or contact an administrator to unlock it, using the Contact form."
-msgstr "Su cuenta fue bloqueada debido a un número repetido de intentos de acceso con una contraseña inválida. Su cuenta continuará bloqueada por las próximas ${hrs} horas. Puede alterar su contraseña, o contactar un administrador para desbloquearla, utilizando el formulario de contacto."
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:22
+msgid "You must enable cookies before you can log in."
+msgstr "Debe habilitar las cookies antes de iniciar la sesión."
 
-#: collective/pwexpiry/example_validator.py:72
-msgid "Your password cannot contain your account name(Username), first name or last name."
-msgstr "Su contraseña no puede contener su nombre de usuario, su nombre, ni su apellido."
+#: ./collective/pwexpiry/example_validator.py:72
+msgid ""
+"Your password cannot contain your account name(Username), first name or last"
+" name."
+msgstr ""
+"Su contraseña no puede contener su nombre de usuario, su nombre, ni su"
+" apellido."
 
-#: collective/pwexpiry/pwexpiry_plugin.py:106
+#: ./collective/pwexpiry/pwexpiry_plugin.py:106
 msgid "Your password has expired."
 msgstr "Su contraseña expiró."
 
 #. Default: "\n\nIn order to change your password, please visit ${server_url}/@@change-password"
-#: collective/pwexpiry/browser/emails/emails.py:63
+#: ./collective/pwexpiry/browser/emails/emails.py:63
 msgid "change_password_email_text"
-msgstr "Para alterar su contraseña por favor visite ${server_url}/@@change-password"
+msgstr ""
+"Para alterar su contraseña por favor visite ${server_url}/@@change-password"
 
-#: collective/pwexpiry/configure.zcml:29
+#: ./collective/pwexpiry/configure.zcml:29
 msgid "collective.pwexpiry"
 msgstr ""
 
-#: collective/pwexpiry/configure.zcml:37
+#: ./collective/pwexpiry/configure.zcml:37
 msgid "collective.pwexpiry: Plone 4 only profile"
 msgstr ""
 
-#: collective/pwexpiry/configure.zcml:45
+#: ./collective/pwexpiry/configure.zcml:45
 msgid "collective.pwexpiry: uninstall"
 msgstr ""
 
 #. Default: "Show all search results"
-#: collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.pt:157
+#: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.pt:157
 msgid "description_pas_show_all_search_results"
 msgstr "Mostrar todos los resultados de la búsqueda"
 
 #. Default: "View and manage user's password expiration properties"
-#: collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.pt:50
+#: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.pt:50
 msgid "description_password_expiration"
-msgstr "Ver y gerenciar las propiedades de expiración de las contraseñas de los usuarios"
+msgstr ""
+"Ver y gerenciar las propiedades de expiración de las contraseñas de los"
+" usuarios"
 
 #. Default: "${days} days left to password expiration"
-#: collective/pwexpiry/utils.py:35
+#: ./collective/pwexpiry/utils.py:35
 msgid "email_subject"
 msgstr "Quedan ${days} días para que su contraseña expire"
 
 #. Default: "Hello ${fullname},\n\nThere are ${days} days left before your password expires!\n\nPlease ensure to reset your password before it's expired."
-#: collective/pwexpiry/browser/emails/emails.py:51
+#: ./collective/pwexpiry/browser/emails/emails.py:51
 msgid "email_text"
 msgstr ""
 "Hola ${fullname},\n"
@@ -115,7 +181,7 @@ msgstr ""
 "Por favor asegúrese de cambiarla antes de que esto suceda."
 
 #. Default: "Hello ${fullname},\n\nYour password has expired.\n\nPlease ensure to reset your password before it's expired."
-#: collective/pwexpiry/browser/emails/emails.py:71
+#: ./collective/pwexpiry/browser/emails/emails.py:71
 msgid "email_text_expired"
 msgstr ""
 "Hola ${fullname},\n"
@@ -125,51 +191,54 @@ msgstr ""
 "Por favor asegúrese de cambiarla."
 
 #. Default: "The date of performing the last notification for the user"
-#: collective/pwexpiry/userdataschema.py:32
+#: ./collective/pwexpiry/userdataschema.py:32
 msgid "help_last_notification_date"
 msgstr "La fecha de la última notificación al usuario"
 
 #. Default: "The date of setting the password"
-#: collective/pwexpiry/userdataschema.py:22
+#: ./collective/pwexpiry/userdataschema.py:22
 msgid "help_password_date"
 msgstr "La fecha en que la contraseña fue alterada"
 
 #. Default: "This password has been used already."
-#: collective/pwexpiry/password_history_validator.py:51
+#: ./collective/pwexpiry/password_history_validator.py:51
 msgid "info_reused_pw"
 msgstr "Esta contraseña ya fue utilizada."
 
 #. Default: "Apply Changes"
-#: collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.pt:169
+#: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.pt:169
 msgid "label_apply_changes"
 msgstr "Aplicar cambios"
 
 #. Default: "Last notification date"
-#: collective/pwexpiry/userdataschema.py:29
+#: ./collective/pwexpiry/userdataschema.py:29
 msgid "label_last_notification_date"
 msgstr "Fecha de la última notificación"
 
 #. Default: "Password date"
-#: collective/pwexpiry/userdataschema.py:21
+#: ./collective/pwexpiry/userdataschema.py:21
 msgid "label_password_date"
 msgstr "Fecha de la contraseña"
 
 #. Default: "Save whitelist"
-#: collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.pt:194
+#: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.pt:194
 msgid "label_save_whitelist"
 msgstr "Guardar lista de ignorados"
 
 #. Default: "Users whitelisted"
-#: collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.pt:189
+#: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.pt:189
 msgid "label_whitelist_users"
 msgstr "Usuarios ignorados"
 
 #. Default: "\n\nIn order to reset your password, please visit ${server_url}/mail_password_form?userid=${username}"
-#: collective/pwexpiry/browser/emails/emails.py:83
+#: ./collective/pwexpiry/browser/emails/emails.py:83
 msgid "reset_password_email_text"
-msgstr "Para alterar su contraseña visite ${server_url}/mail_password_form?userid=${username}"
+msgstr ""
+"Para alterar su contraseña visite ${server_url}/mail_password_form?userid=${us"
+"ername}"
 
 #. Default: "\n\nThis email was sent from ${server_name}"
-#: collective/pwexpiry/browser/emails/emails.py:92
+#: ./collective/pwexpiry/browser/emails/emails.py:92
 msgid "server_name_email_text"
 msgstr "Este mensaje fue enviado desde ${server_name}"
+

--- a/collective/pwexpiry/locales/es/LC_MESSAGES/collective.pwexpiry.po
+++ b/collective/pwexpiry/locales/es/LC_MESSAGES/collective.pwexpiry.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2018-11-15 21:09+0000\n"
+"POT-Creation-Date: 2018-11-16 14:09+0000\n"
 "PO-Revision-Date: 2018-11-15 18:28-0300\n"
 "Last-Translator: Franco Pellegrini <franco.pellegrini@enfoldsystems.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -23,37 +23,23 @@ msgstr "Adiciona control de expiración de contraseñas."
 
 #: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:67
 msgid "Email address not known."
-msgstr "Dirección de correo desconocida."
+msgstr ""
 
 #: ./collective/pwexpiry/pwdisable_plugin.py:64
 #: ./collective/pwexpiry/skins/pwexpiry/logged_in.cpy:26
 #: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:81
-msgid ""
-"Login failed. Both email address and password are case sensitive, check that"
-" caps lock is not enabled. If you have entered your password correctly, your"
-" account might be locked."
+msgid "Login failed. Both email address and password are case sensitive, check that caps lock is not enabled. If you have entered your password correctly, your account might be locked. You can reset your password, or contact an administrator to unlock it, using the Contact form."
 msgstr ""
-"Error en el inicio de sesión. Tanto la dirección del correo como la"
-" contraseña son sensibles a la capitalización, comprueba que la tecla Bloq"
-" Mayús no está activa. Si ha introducido su contraseña de manera correcta, es"
-" posible que su cuenta se encuentre bloqueada."
 
-#: ./collective/pwexpiry/pwdisable_plugin.py:72
-#: ./collective/pwexpiry/skins/pwexpiry/logged_in.cpy:33
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:88
-msgid ""
-"Login failed. Both login name and password are case sensitive, check that"
-" caps lock is not enabled. If you have entered your password correctly, your"
-" account might be locked."
+#: ./collective/pwexpiry/pwdisable_plugin.py:73
+#: ./collective/pwexpiry/skins/pwexpiry/logged_in.cpy:34
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:89
+msgid "Login failed. Both login name and password are case sensitive, check that caps lock is not enabled. If you have entered your password correctly, your account might be locked. You can reset your password, or contact an administrator to unlock it, using the Contact form."
 msgstr ""
-"Error en el inicio de sesión. Tanto el nombre de inicio de sesión como la"
-" contraseña son sensibles a la capitalización, comprueba que la tecla de"
-" bloqueo de mayúsculas no está habilitada. Si ha introducido su contraseña de"
-" manera correcta, es posible que su cuenta se encuentre bloqueada."
 
 #: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:72
 msgid "Login name not found."
-msgstr "Nombre de inicio de sesión no encontrado."
+msgstr ""
 
 #: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.py:134
 msgid "Never"
@@ -69,38 +55,30 @@ msgstr "Expiración de contraseña"
 
 #: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:77
 msgid "Password incorrect."
-msgstr "Contraseña incorrecta."
+msgstr ""
 
 #: ./collective/pwexpiry/example_validator.py:41
 msgid "Passwords must be at least 8 characters in length."
 msgstr "Las contraseñas deben tener por lo menos 8 caracteres."
 
 #: ./collective/pwexpiry/example_validator.py:98
-msgid ""
-"Passwords must contain at least three of the following four character groups:"
-" Uppercase characters (A through Z), Lowercase characters (a through z),"
-" Numerals (0 through 9), Special characters such as !, $, #, %"
-msgstr ""
-"Las contraseñas deben contener al menos 3 de los siguientes 4 grupos de"
-" caracteres: letras mayúsculas (A-Z), letras minúsculas (a-z), números (0-9)"
-" y caracteres especiales como !, $, #, %."
+msgid "Passwords must contain at least three of the following four character groups: Uppercase characters (A through Z), Lowercase characters (a through z), Numerals (0 through 9), Special characters such as !, $, #, %"
+msgstr "Las contraseñas deben contener al menos 3 de los siguientes 4 grupos de caracteres: letras mayúsculas (A-Z), letras minúsculas (a-z), números (0-9) y caracteres especiales como !, $, #, %."
 
 #: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:48
 msgid "Please enter your email address."
-msgstr "Por favor, introduzca su dirección de correo."
+msgstr ""
 
 #: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:53
 msgid "Please enter your login name."
-msgstr "Por favor, introduzca su nombre de inicio de sesión."
+msgstr ""
 
 #: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:58
 msgid "Please enter your password."
-msgstr "Por favor, introduzca su contraseña."
+msgstr ""
 
 #: ./collective/pwexpiry/configure.zcml:37
-msgid ""
-"Profile intended only in Plone 4 (No need to manually run it, default install"
-" profile should do it)."
+msgid "Profile intended only in Plone 4 (No need to manually run it, default install profile should do it)."
 msgstr ""
 
 #: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.py:126
@@ -121,15 +99,11 @@ msgstr "Usted tiene que modificar su contraseña."
 
 #: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:22
 msgid "You must enable cookies before you can log in."
-msgstr "Debe habilitar las cookies antes de iniciar la sesión."
+msgstr ""
 
 #: ./collective/pwexpiry/example_validator.py:72
-msgid ""
-"Your password cannot contain your account name(Username), first name or last"
-" name."
-msgstr ""
-"Su contraseña no puede contener su nombre de usuario, su nombre, ni su"
-" apellido."
+msgid "Your password cannot contain your account name(Username), first name or last name."
+msgstr "Su contraseña no puede contener su nombre de usuario, su nombre, ni su apellido."
 
 #: ./collective/pwexpiry/pwexpiry_plugin.py:106
 msgid "Your password has expired."
@@ -138,8 +112,7 @@ msgstr "Su contraseña expiró."
 #. Default: "\n\nIn order to change your password, please visit ${server_url}/@@change-password"
 #: ./collective/pwexpiry/browser/emails/emails.py:63
 msgid "change_password_email_text"
-msgstr ""
-"Para alterar su contraseña por favor visite ${server_url}/@@change-password"
+msgstr "Para alterar su contraseña por favor visite ${server_url}/@@change-password"
 
 #: ./collective/pwexpiry/configure.zcml:29
 msgid "collective.pwexpiry"
@@ -161,9 +134,7 @@ msgstr "Mostrar todos los resultados de la búsqueda"
 #. Default: "View and manage user's password expiration properties"
 #: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.pt:50
 msgid "description_password_expiration"
-msgstr ""
-"Ver y gerenciar las propiedades de expiración de las contraseñas de los"
-" usuarios"
+msgstr "Ver y gerenciar las propiedades de expiración de las contraseñas de los usuarios"
 
 #. Default: "${days} days left to password expiration"
 #: ./collective/pwexpiry/utils.py:35
@@ -233,12 +204,9 @@ msgstr "Usuarios ignorados"
 #. Default: "\n\nIn order to reset your password, please visit ${server_url}/mail_password_form?userid=${username}"
 #: ./collective/pwexpiry/browser/emails/emails.py:83
 msgid "reset_password_email_text"
-msgstr ""
-"Para alterar su contraseña visite ${server_url}/mail_password_form?userid=${us"
-"ername}"
+msgstr "Para alterar su contraseña visite ${server_url}/mail_password_form?userid=${username}"
 
 #. Default: "\n\nThis email was sent from ${server_name}"
 #: ./collective/pwexpiry/browser/emails/emails.py:92
 msgid "server_name_email_text"
 msgstr "Este mensaje fue enviado desde ${server_name}"
-

--- a/collective/pwexpiry/locales/it/LC_MESSAGES/collective.pwexpiry.po
+++ b/collective/pwexpiry/locales/it/LC_MESSAGES/collective.pwexpiry.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2018-11-15 21:09+0000\n"
+"POT-Creation-Date: 2018-11-16 14:09+0000\n"
 "PO-Revision-Date: 2018-11-15 18:27-0300\n"
 "Last-Translator: Franco Pellegrini <franco.pellegrini@enfoldsystems.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -24,36 +24,23 @@ msgstr ""
 
 #: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:67
 msgid "Email address not known."
-msgstr "Indirizzo email sconosciuto."
+msgstr ""
 
 #: ./collective/pwexpiry/pwdisable_plugin.py:64
-#, fuzzy
 #: ./collective/pwexpiry/skins/pwexpiry/logged_in.cpy:26
 #: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:81
-msgid ""
-"Login failed. Both email address and password are case sensitive, check that"
-" caps lock is not enabled. If you have entered your password correctly, your"
-" account might be locked."
+msgid "Login failed. Both email address and password are case sensitive, check that caps lock is not enabled. If you have entered your password correctly, your account might be locked. You can reset your password, or contact an administrator to unlock it, using the Contact form."
 msgstr ""
-"Login fallito. L'email e la password tengono conto del maiuscolo/minuscolo,"
-" controlla che il blocco delle maiuscole non sia attivato."
 
-#: ./collective/pwexpiry/pwdisable_plugin.py:72
-#, fuzzy
-#: ./collective/pwexpiry/skins/pwexpiry/logged_in.cpy:33
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:88
-msgid ""
-"Login failed. Both login name and password are case sensitive, check that"
-" caps lock is not enabled. If you have entered your password correctly, your"
-" account might be locked."
+#: ./collective/pwexpiry/pwdisable_plugin.py:73
+#: ./collective/pwexpiry/skins/pwexpiry/logged_in.cpy:34
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:89
+msgid "Login failed. Both login name and password are case sensitive, check that caps lock is not enabled. If you have entered your password correctly, your account might be locked. You can reset your password, or contact an administrator to unlock it, using the Contact form."
 msgstr ""
-"Riconoscimento fallito. Sia il nome utente che la password tengono conto del"
-" maiuscolo/minuscolo, controlla che il blocco delle maiuscole non sia"
-" attivato."
 
 #: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:72
 msgid "Login name not found."
-msgstr "Nome utente non trovato."
+msgstr ""
 
 #: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.py:134
 msgid "Never"
@@ -69,35 +56,30 @@ msgstr "Scadenza della password"
 
 #: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:77
 msgid "Password incorrect."
-msgstr "Password non corretta."
+msgstr ""
 
 #: ./collective/pwexpiry/example_validator.py:41
 msgid "Passwords must be at least 8 characters in length."
 msgstr ""
 
 #: ./collective/pwexpiry/example_validator.py:98
-msgid ""
-"Passwords must contain at least three of the following four character groups:"
-" Uppercase characters (A through Z), Lowercase characters (a through z),"
-" Numerals (0 through 9), Special characters such as !, $, #, %"
+msgid "Passwords must contain at least three of the following four character groups: Uppercase characters (A through Z), Lowercase characters (a through z), Numerals (0 through 9), Special characters such as !, $, #, %"
 msgstr ""
 
 #: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:48
 msgid "Please enter your email address."
-msgstr "Inserisci il tuo indirizzo email."
+msgstr ""
 
 #: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:53
 msgid "Please enter your login name."
-msgstr "Inserisci il tuo nome utente."
+msgstr ""
 
 #: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:58
 msgid "Please enter your password."
-msgstr "Inserisci la tua password."
+msgstr ""
 
 #: ./collective/pwexpiry/configure.zcml:37
-msgid ""
-"Profile intended only in Plone 4 (No need to manually run it, default install"
-" profile should do it)."
+msgid "Profile intended only in Plone 4 (No need to manually run it, default install profile should do it)."
 msgstr ""
 
 #: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.py:126
@@ -118,12 +100,10 @@ msgstr ""
 
 #: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:22
 msgid "You must enable cookies before you can log in."
-msgstr "Devi abilitare i cookie per poter essere riconosciuto."
+msgstr ""
 
 #: ./collective/pwexpiry/example_validator.py:72
-msgid ""
-"Your password cannot contain your account name(Username), first name or last"
-" name."
+msgid "Your password cannot contain your account name(Username), first name or last name."
 msgstr ""
 
 #: ./collective/pwexpiry/pwexpiry_plugin.py:106
@@ -221,4 +201,3 @@ msgstr ""
 #: ./collective/pwexpiry/browser/emails/emails.py:92
 msgid "server_name_email_text"
 msgstr ""
-

--- a/collective/pwexpiry/locales/it/LC_MESSAGES/collective.pwexpiry.po
+++ b/collective/pwexpiry/locales/it/LC_MESSAGES/collective.pwexpiry.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2018-11-16 14:09+0000\n"
+"POT-Creation-Date: 2018-11-20 14:25+0000\n"
 "PO-Revision-Date: 2018-11-15 18:27-0300\n"
 "Last-Translator: Franco Pellegrini <franco.pellegrini@enfoldsystems.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -22,24 +22,16 @@ msgstr ""
 msgid "Adds the feature of password expiration control."
 msgstr ""
 
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:67
-msgid "Email address not known."
-msgstr ""
-
 #: ./collective/pwexpiry/pwdisable_plugin.py:64
 #: ./collective/pwexpiry/skins/pwexpiry/logged_in.cpy:26
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:81
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:82
 msgid "Login failed. Both email address and password are case sensitive, check that caps lock is not enabled. If you have entered your password correctly, your account might be locked. You can reset your password, or contact an administrator to unlock it, using the Contact form."
 msgstr ""
 
 #: ./collective/pwexpiry/pwdisable_plugin.py:73
 #: ./collective/pwexpiry/skins/pwexpiry/logged_in.cpy:34
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:89
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:90
 msgid "Login failed. Both login name and password are case sensitive, check that caps lock is not enabled. If you have entered your password correctly, your account might be locked. You can reset your password, or contact an administrator to unlock it, using the Contact form."
-msgstr ""
-
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:72
-msgid "Login name not found."
 msgstr ""
 
 #: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.py:134
@@ -54,28 +46,12 @@ msgstr "Nessun utente è stato sbloccato"
 msgid "Password expiration"
 msgstr "Scadenza della password"
 
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:77
-msgid "Password incorrect."
-msgstr ""
-
 #: ./collective/pwexpiry/example_validator.py:41
 msgid "Passwords must be at least 8 characters in length."
 msgstr ""
 
 #: ./collective/pwexpiry/example_validator.py:98
 msgid "Passwords must contain at least three of the following four character groups: Uppercase characters (A through Z), Lowercase characters (a through z), Numerals (0 through 9), Special characters such as !, $, #, %"
-msgstr ""
-
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:48
-msgid "Please enter your email address."
-msgstr ""
-
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:53
-msgid "Please enter your login name."
-msgstr ""
-
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:58
-msgid "Please enter your password."
 msgstr ""
 
 #: ./collective/pwexpiry/configure.zcml:37
@@ -96,10 +72,6 @@ msgstr "Pannello della scadenza della password degli utenti"
 
 #: ./collective/pwexpiry/example_validator.py:80
 msgid "You have to change your password."
-msgstr ""
-
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:22
-msgid "You must enable cookies before you can log in."
 msgstr ""
 
 #: ./collective/pwexpiry/example_validator.py:72

--- a/collective/pwexpiry/locales/it/LC_MESSAGES/collective.pwexpiry.po
+++ b/collective/pwexpiry/locales/it/LC_MESSAGES/collective.pwexpiry.po
@@ -1,23 +1,59 @@
 # Giacomo Spettoli <giacomo.spettoli@returtle.it>, 2014.
+# Franco Pellegrini <franco.pellegrini@enfoldsystems.com>, 2018.
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2018-11-07 18:36+0000\n"
-"PO-Revision-Date: 2015-04-21 15:53+0000\n"
-"Last-Translator: Giacomo Spettoli <giacomo.spettoli@gmail.com>\n"
-"Language-Team: Plone Italian Translation Discussion <plone-italian-translation-discussion@lists.coactivate.org>\n"
+"POT-Creation-Date: 2018-11-15 21:09+0000\n"
+"PO-Revision-Date: 2018-11-15 18:27-0300\n"
+"Last-Translator: Franco Pellegrini <franco.pellegrini@enfoldsystems.com>\n"
+"Language-Team: English <kde-i18n-doc@kde.org>\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0\n"
 "Language-Code: it\n"
 "Language-Name: Italian\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: collective.pwexpiry\n"
+"Language: en_US\n"
+"X-Generator: Lokalize 2.0\n"
 
 #: ./collective/pwexpiry/configure.zcml:29
 msgid "Adds the feature of password expiration control."
 msgstr ""
+
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:67
+msgid "Email address not known."
+msgstr "Indirizzo email sconosciuto."
+
+#: ./collective/pwexpiry/pwdisable_plugin.py:64
+#, fuzzy
+#: ./collective/pwexpiry/skins/pwexpiry/logged_in.cpy:26
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:81
+msgid ""
+"Login failed. Both email address and password are case sensitive, check that"
+" caps lock is not enabled. If you have entered your password correctly, your"
+" account might be locked."
+msgstr ""
+"Login fallito. L'email e la password tengono conto del maiuscolo/minuscolo,"
+" controlla che il blocco delle maiuscole non sia attivato."
+
+#: ./collective/pwexpiry/pwdisable_plugin.py:72
+#, fuzzy
+#: ./collective/pwexpiry/skins/pwexpiry/logged_in.cpy:33
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:88
+msgid ""
+"Login failed. Both login name and password are case sensitive, check that"
+" caps lock is not enabled. If you have entered your password correctly, your"
+" account might be locked."
+msgstr ""
+"Riconoscimento fallito. Sia il nome utente che la password tengono conto del"
+" maiuscolo/minuscolo, controlla che il blocco delle maiuscole non sia"
+" attivato."
+
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:72
+msgid "Login name not found."
+msgstr "Nome utente non trovato."
 
 #: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.py:134
 msgid "Never"
@@ -31,16 +67,37 @@ msgstr "Nessun utente è stato sbloccato"
 msgid "Password expiration"
 msgstr "Scadenza della password"
 
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:77
+msgid "Password incorrect."
+msgstr "Password non corretta."
+
 #: ./collective/pwexpiry/example_validator.py:41
 msgid "Passwords must be at least 8 characters in length."
 msgstr ""
 
 #: ./collective/pwexpiry/example_validator.py:98
-msgid "Passwords must contain at least three of the following four character groups: Uppercase characters (A through Z), Lowercase characters (a through z), Numerals (0 through 9), Special characters such as !, $, #, %"
+msgid ""
+"Passwords must contain at least three of the following four character groups:"
+" Uppercase characters (A through Z), Lowercase characters (a through z),"
+" Numerals (0 through 9), Special characters such as !, $, #, %"
 msgstr ""
 
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:48
+msgid "Please enter your email address."
+msgstr "Inserisci il tuo indirizzo email."
+
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:53
+msgid "Please enter your login name."
+msgstr "Inserisci il tuo nome utente."
+
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:58
+msgid "Please enter your password."
+msgstr "Inserisci la tua password."
+
 #: ./collective/pwexpiry/configure.zcml:37
-msgid "Profile intended only in Plone 4 (No need to manually run it, default install profile should do it)."
+msgid ""
+"Profile intended only in Plone 4 (No need to manually run it, default install"
+" profile should do it)."
 msgstr ""
 
 #: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.py:126
@@ -59,12 +116,14 @@ msgstr "Pannello della scadenza della password degli utenti"
 msgid "You have to change your password."
 msgstr ""
 
-#: ./collective/pwexpiry/pwdisable_plugin.py:58
-msgid "Your account has been locked due to too many invalid attempts to login with a wrong password. Your account will remain blocked for the next ${hrs} hours. You can reset your password, or contact an administrator to unlock it, using the Contact form."
-msgstr "Il tuo account è stato bloccato a causa di troppi tentativi falliti di login con una password errata. Il tuo account rimarrà bloccato per le prossime ${hrs} ore. Puoi resettare la tua password oppure contattare l'amministratore del sito per sbloccarti, usando i form di contatti."
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:22
+msgid "You must enable cookies before you can log in."
+msgstr "Devi abilitare i cookie per poter essere riconosciuto."
 
 #: ./collective/pwexpiry/example_validator.py:72
-msgid "Your password cannot contain your account name(Username), first name or last name."
+msgid ""
+"Your password cannot contain your account name(Username), first name or last"
+" name."
 msgstr ""
 
 #: ./collective/pwexpiry/pwexpiry_plugin.py:106
@@ -162,3 +221,4 @@ msgstr ""
 #: ./collective/pwexpiry/browser/emails/emails.py:92
 msgid "server_name_email_text"
 msgstr ""
+

--- a/collective/pwexpiry/locales/pt_BR/LC_MESSAGES/collective.pwexpiry.po
+++ b/collective/pwexpiry/locales/pt_BR/LC_MESSAGES/collective.pwexpiry.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2018-11-16 14:09+0000\n"
+"POT-Creation-Date: 2018-11-20 14:25+0000\n"
 "PO-Revision-Date: 2018-11-15 18:31-0300\n"
 "Last-Translator: Franco Pellegrini <franco.pellegrini@enfoldsystems.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -21,24 +21,16 @@ msgstr ""
 msgid "Adds the feature of password expiration control."
 msgstr "Adiciona controle de expiração de senhas."
 
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:67
-msgid "Email address not known."
-msgstr ""
-
 #: ./collective/pwexpiry/pwdisable_plugin.py:64
 #: ./collective/pwexpiry/skins/pwexpiry/logged_in.cpy:26
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:81
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:82
 msgid "Login failed. Both email address and password are case sensitive, check that caps lock is not enabled. If you have entered your password correctly, your account might be locked. You can reset your password, or contact an administrator to unlock it, using the Contact form."
 msgstr ""
 
 #: ./collective/pwexpiry/pwdisable_plugin.py:73
 #: ./collective/pwexpiry/skins/pwexpiry/logged_in.cpy:34
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:89
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:90
 msgid "Login failed. Both login name and password are case sensitive, check that caps lock is not enabled. If you have entered your password correctly, your account might be locked. You can reset your password, or contact an administrator to unlock it, using the Contact form."
-msgstr ""
-
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:72
-msgid "Login name not found."
 msgstr ""
 
 #: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.py:134
@@ -53,10 +45,6 @@ msgstr "Não existem usuários bloqueados"
 msgid "Password expiration"
 msgstr "Expiração de senha"
 
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:77
-msgid "Password incorrect."
-msgstr ""
-
 #: ./collective/pwexpiry/example_validator.py:41
 msgid "Passwords must be at least 8 characters in length."
 msgstr "As senhas devem ter pelo menos 8 caracteres."
@@ -64,18 +52,6 @@ msgstr "As senhas devem ter pelo menos 8 caracteres."
 #: ./collective/pwexpiry/example_validator.py:98
 msgid "Passwords must contain at least three of the following four character groups: Uppercase characters (A through Z), Lowercase characters (a through z), Numerals (0 through 9), Special characters such as !, $, #, %"
 msgstr "As senhas devem ter pelo menos 3 dos seguintes 4 grupos de caracteres: letras maiúsculas (A-Z), letras minúsculas (a-z), números (0-9) e caracteres especiais como !, $, #, %."
-
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:48
-msgid "Please enter your email address."
-msgstr ""
-
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:53
-msgid "Please enter your login name."
-msgstr ""
-
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:58
-msgid "Please enter your password."
-msgstr ""
 
 #: ./collective/pwexpiry/configure.zcml:37
 msgid "Profile intended only in Plone 4 (No need to manually run it, default install profile should do it)."
@@ -96,10 +72,6 @@ msgstr "Painel de expiração das senhas dos usuários"
 #: ./collective/pwexpiry/example_validator.py:80
 msgid "You have to change your password."
 msgstr "Você precisa modificar sua senha."
-
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:22
-msgid "You must enable cookies before you can log in."
-msgstr ""
 
 #: ./collective/pwexpiry/example_validator.py:72
 msgid "Your password cannot contain your account name(Username), first name or last name."

--- a/collective/pwexpiry/locales/pt_BR/LC_MESSAGES/collective.pwexpiry.po
+++ b/collective/pwexpiry/locales/pt_BR/LC_MESSAGES/collective.pwexpiry.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2018-11-15 21:09+0000\n"
+"POT-Creation-Date: 2018-11-16 14:09+0000\n"
 "PO-Revision-Date: 2018-11-15 18:31-0300\n"
 "Last-Translator: Franco Pellegrini <franco.pellegrini@enfoldsystems.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -23,35 +23,23 @@ msgstr "Adiciona controle de expiração de senhas."
 
 #: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:67
 msgid "Email address not known."
-msgstr "E-mail desconhecido."
+msgstr ""
 
 #: ./collective/pwexpiry/pwdisable_plugin.py:64
-#, fuzzy
 #: ./collective/pwexpiry/skins/pwexpiry/logged_in.cpy:26
 #: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:81
-msgid ""
-"Login failed. Both email address and password are case sensitive, check that"
-" caps lock is not enabled. If you have entered your password correctly, your"
-" account might be locked."
+msgid "Login failed. Both email address and password are case sensitive, check that caps lock is not enabled. If you have entered your password correctly, your account might be locked. You can reset your password, or contact an administrator to unlock it, using the Contact form."
 msgstr ""
-"Autenticação falhou. Tanto e-mail como a senha são sensíveis a letras"
-" maiúsculas e minúsculas, verifique se a tecla Caps Lock não está ativa."
 
-#: ./collective/pwexpiry/pwdisable_plugin.py:72
-#, fuzzy
-#: ./collective/pwexpiry/skins/pwexpiry/logged_in.cpy:33
-#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:88
-msgid ""
-"Login failed. Both login name and password are case sensitive, check that"
-" caps lock is not enabled. If you have entered your password correctly, your"
-" account might be locked."
+#: ./collective/pwexpiry/pwdisable_plugin.py:73
+#: ./collective/pwexpiry/skins/pwexpiry/logged_in.cpy:34
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:89
+msgid "Login failed. Both login name and password are case sensitive, check that caps lock is not enabled. If you have entered your password correctly, your account might be locked. You can reset your password, or contact an administrator to unlock it, using the Contact form."
 msgstr ""
-"Falha no acesso. Tanto o nome de usuário como a senha são sensíveis a letras"
-" maiúsculas e minúsculas, verifique se a tecla Caps Lock não está ativa."
 
 #: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:72
 msgid "Login name not found."
-msgstr "Nome de usuário não encontrado."
+msgstr ""
 
 #: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.py:134
 msgid "Never"
@@ -67,38 +55,30 @@ msgstr "Expiração de senha"
 
 #: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:77
 msgid "Password incorrect."
-msgstr "Senha incorreta."
+msgstr ""
 
 #: ./collective/pwexpiry/example_validator.py:41
 msgid "Passwords must be at least 8 characters in length."
 msgstr "As senhas devem ter pelo menos 8 caracteres."
 
 #: ./collective/pwexpiry/example_validator.py:98
-msgid ""
-"Passwords must contain at least three of the following four character groups:"
-" Uppercase characters (A through Z), Lowercase characters (a through z),"
-" Numerals (0 through 9), Special characters such as !, $, #, %"
-msgstr ""
-"As senhas devem ter pelo menos 3 dos seguintes 4 grupos de caracteres: letras"
-" maiúsculas (A-Z), letras minúsculas (a-z), números (0-9) e caracteres"
-" especiais como !, $, #, %."
+msgid "Passwords must contain at least three of the following four character groups: Uppercase characters (A through Z), Lowercase characters (a through z), Numerals (0 through 9), Special characters such as !, $, #, %"
+msgstr "As senhas devem ter pelo menos 3 dos seguintes 4 grupos de caracteres: letras maiúsculas (A-Z), letras minúsculas (a-z), números (0-9) e caracteres especiais como !, $, #, %."
 
 #: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:48
 msgid "Please enter your email address."
-msgstr "Por favor insira seu e-mail."
+msgstr ""
 
 #: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:53
 msgid "Please enter your login name."
-msgstr "Por favor, informe seu nome de usuário."
+msgstr ""
 
 #: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:58
 msgid "Please enter your password."
-msgstr "Por favor, informe sua senha."
+msgstr ""
 
 #: ./collective/pwexpiry/configure.zcml:37
-msgid ""
-"Profile intended only in Plone 4 (No need to manually run it, default install"
-" profile should do it)."
+msgid "Profile intended only in Plone 4 (No need to manually run it, default install profile should do it)."
 msgstr ""
 
 #: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.py:126
@@ -119,14 +99,11 @@ msgstr "Você precisa modificar sua senha."
 
 #: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:22
 msgid "You must enable cookies before you can log in."
-msgstr "Você precisa habilitar os cookies antes de poder acessar."
+msgstr ""
 
 #: ./collective/pwexpiry/example_validator.py:72
-msgid ""
-"Your password cannot contain your account name(Username), first name or last"
-" name."
-msgstr ""
-"Sua senha não pode conter seu nome de usuário, seu nome, nem seu sobrenome."
+msgid "Your password cannot contain your account name(Username), first name or last name."
+msgstr "Sua senha não pode conter seu nome de usuário, seu nome, nem seu sobrenome."
 
 #: ./collective/pwexpiry/pwexpiry_plugin.py:106
 msgid "Your password has expired."
@@ -135,8 +112,7 @@ msgstr "Sua senha expirou."
 #. Default: "\n\nIn order to change your password, please visit ${server_url}/@@change-password"
 #: ./collective/pwexpiry/browser/emails/emails.py:63
 msgid "change_password_email_text"
-msgstr ""
-"Para alterar sua senha por favor visite ${server_url}/@@change-password"
+msgstr "Para alterar sua senha por favor visite ${server_url}/@@change-password"
 
 #: ./collective/pwexpiry/configure.zcml:29
 msgid "collective.pwexpiry"
@@ -228,12 +204,9 @@ msgstr "Usuários ignorados"
 #. Default: "\n\nIn order to reset your password, please visit ${server_url}/mail_password_form?userid=${username}"
 #: ./collective/pwexpiry/browser/emails/emails.py:83
 msgid "reset_password_email_text"
-msgstr ""
-"Para alterar sua senha visite ${server_url}/mail_password_form?userid=${userna"
-"me}"
+msgstr "Para alterar sua senha visite ${server_url}/mail_password_form?userid=${username}"
 
 #. Default: "\n\nThis email was sent from ${server_name}"
 #: ./collective/pwexpiry/browser/emails/emails.py:92
 msgid "server_name_email_text"
 msgstr "Esta mensagem foi enviada desde ${server_name}"
-

--- a/collective/pwexpiry/locales/pt_BR/LC_MESSAGES/collective.pwexpiry.po
+++ b/collective/pwexpiry/locales/pt_BR/LC_MESSAGES/collective.pwexpiry.po
@@ -1,111 +1,172 @@
+# Franco Pellegrini <franco.pellegrini@enfoldsystems.com>, 2018.
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2018-11-07 18:36+0000\n"
-"PO-Revision-Date: 2018-11-07 18:32-0200\n"
+"POT-Creation-Date: 2018-11-15 21:09+0000\n"
+"PO-Revision-Date: 2018-11-15 18:31-0300\n"
+"Last-Translator: Franco Pellegrini <franco.pellegrini@enfoldsystems.com>\n"
+"Language-Team: English <kde-i18n-doc@kde.org>\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "Language-Code: en\n"
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
-"Last-Translator: \n"
-"Language-Team: \n"
 "Language: pt_BR\n"
-"X-Generator: Poedit 1.8.7.1\n"
+"X-Generator: Lokalize 2.0\n"
 
-#: collective/pwexpiry/configure.zcml:29
+#: ./collective/pwexpiry/configure.zcml:29
 msgid "Adds the feature of password expiration control."
 msgstr "Adiciona controle de expiração de senhas."
 
-#: collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.py:134
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:67
+msgid "Email address not known."
+msgstr "E-mail desconhecido."
+
+#: ./collective/pwexpiry/pwdisable_plugin.py:64
+#, fuzzy
+#: ./collective/pwexpiry/skins/pwexpiry/logged_in.cpy:26
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:81
+msgid ""
+"Login failed. Both email address and password are case sensitive, check that"
+" caps lock is not enabled. If you have entered your password correctly, your"
+" account might be locked."
+msgstr ""
+"Autenticação falhou. Tanto e-mail como a senha são sensíveis a letras"
+" maiúsculas e minúsculas, verifique se a tecla Caps Lock não está ativa."
+
+#: ./collective/pwexpiry/pwdisable_plugin.py:72
+#, fuzzy
+#: ./collective/pwexpiry/skins/pwexpiry/logged_in.cpy:33
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:88
+msgid ""
+"Login failed. Both login name and password are case sensitive, check that"
+" caps lock is not enabled. If you have entered your password correctly, your"
+" account might be locked."
+msgstr ""
+"Falha no acesso. Tanto o nome de usuário como a senha são sensíveis a letras"
+" maiúsculas e minúsculas, verifique se a tecla Caps Lock não está ativa."
+
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:72
+msgid "Login name not found."
+msgstr "Nome de usuário não encontrado."
+
+#: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.py:134
 msgid "Never"
 msgstr "Nunca"
 
-#: collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.py:130
+#: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.py:130
 msgid "No users were unlocked"
 msgstr "Não existem usuários bloqueados"
 
-#: collective/pwexpiry/profiles/default/controlpanel.xml
+#: ./collective/pwexpiry/profiles/default/controlpanel.xml
 msgid "Password expiration"
 msgstr "Expiração de senha"
 
-#: collective/pwexpiry/example_validator.py:41
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:77
+msgid "Password incorrect."
+msgstr "Senha incorreta."
+
+#: ./collective/pwexpiry/example_validator.py:41
 msgid "Passwords must be at least 8 characters in length."
 msgstr "As senhas devem ter pelo menos 8 caracteres."
 
-#: collective/pwexpiry/example_validator.py:98
-msgid "Passwords must contain at least three of the following four character groups: Uppercase characters (A through Z), Lowercase characters (a through z), Numerals (0 through 9), Special characters such as !, $, #, %"
-msgstr "As senhas devem ter pelo menos 3 dos seguintes 4 grupos de caracteres: letras maiúsculas (A-Z), letras minúsculas (a-z), números (0-9) e caracteres especiais como !, $, #, %."
+#: ./collective/pwexpiry/example_validator.py:98
+msgid ""
+"Passwords must contain at least three of the following four character groups:"
+" Uppercase characters (A through Z), Lowercase characters (a through z),"
+" Numerals (0 through 9), Special characters such as !, $, #, %"
+msgstr ""
+"As senhas devem ter pelo menos 3 dos seguintes 4 grupos de caracteres: letras"
+" maiúsculas (A-Z), letras minúsculas (a-z), números (0-9) e caracteres"
+" especiais como !, $, #, %."
 
-#: collective/pwexpiry/configure.zcml:37
-msgid "Profile intended only in Plone 4 (No need to manually run it, default install profile should do it)."
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:48
+msgid "Please enter your email address."
+msgstr "Por favor insira seu e-mail."
+
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:53
+msgid "Please enter your login name."
+msgstr "Por favor, informe seu nome de usuário."
+
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:58
+msgid "Please enter your password."
+msgstr "Por favor, informe sua senha."
+
+#: ./collective/pwexpiry/configure.zcml:37
+msgid ""
+"Profile intended only in Plone 4 (No need to manually run it, default install"
+" profile should do it)."
 msgstr ""
 
-#: collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.py:126
+#: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.py:126
 msgid "The following users were unlocked: %s, "
 msgstr "Os seguintes usuários foram desbloqueados: %s, "
 
-#: collective/pwexpiry/configure.zcml:45
+#: ./collective/pwexpiry/configure.zcml:45
 msgid "Uninstalls collective.pwexpiry."
 msgstr "Desinstala collective.pwexpiry."
 
-#: collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.pt:38
+#: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.pt:38
 msgid "User's password expiration panel"
 msgstr "Painel de expiração das senhas dos usuários"
 
-#: collective/pwexpiry/example_validator.py:80
+#: ./collective/pwexpiry/example_validator.py:80
 msgid "You have to change your password."
 msgstr "Você precisa modificar sua senha."
 
-#: collective/pwexpiry/pwdisable_plugin.py:58
-msgid "Your account has been locked due to too many invalid attempts to login with a wrong password. Your account will remain blocked for the next ${hrs} hours. You can reset your password, or contact an administrator to unlock it, using the Contact form."
-msgstr "Sua conta foi bloqueada devido a um número repetido de tentativas de acesso com uma senha inválida. Sua conta continuará bloqueada pelas próximas ${hrs} horas. Você pode alterar sua senha, ou entrar em contato com um administrador para desbloqueá-la, usando o formulário de contato."
+#: ./collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy:22
+msgid "You must enable cookies before you can log in."
+msgstr "Você precisa habilitar os cookies antes de poder acessar."
 
-#: collective/pwexpiry/example_validator.py:72
-msgid "Your password cannot contain your account name(Username), first name or last name."
-msgstr "Sua senha não pode conter seu nome de usuário, seu nome, nem seu sobrenome."
+#: ./collective/pwexpiry/example_validator.py:72
+msgid ""
+"Your password cannot contain your account name(Username), first name or last"
+" name."
+msgstr ""
+"Sua senha não pode conter seu nome de usuário, seu nome, nem seu sobrenome."
 
-#: collective/pwexpiry/pwexpiry_plugin.py:106
+#: ./collective/pwexpiry/pwexpiry_plugin.py:106
 msgid "Your password has expired."
 msgstr "Sua senha expirou."
 
 #. Default: "\n\nIn order to change your password, please visit ${server_url}/@@change-password"
-#: collective/pwexpiry/browser/emails/emails.py:63
+#: ./collective/pwexpiry/browser/emails/emails.py:63
 msgid "change_password_email_text"
-msgstr "Para alterar sua senha por favor visite ${server_url}/@@change-password"
+msgstr ""
+"Para alterar sua senha por favor visite ${server_url}/@@change-password"
 
-#: collective/pwexpiry/configure.zcml:29
+#: ./collective/pwexpiry/configure.zcml:29
 msgid "collective.pwexpiry"
 msgstr ""
 
-#: collective/pwexpiry/configure.zcml:37
+#: ./collective/pwexpiry/configure.zcml:37
 msgid "collective.pwexpiry: Plone 4 only profile"
 msgstr ""
 
-#: collective/pwexpiry/configure.zcml:45
+#: ./collective/pwexpiry/configure.zcml:45
 msgid "collective.pwexpiry: uninstall"
 msgstr ""
 
 #. Default: "Show all search results"
-#: collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.pt:157
+#: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.pt:157
 msgid "description_pas_show_all_search_results"
 msgstr "Mostrar todos os resultados da busca"
 
 #. Default: "View and manage user's password expiration properties"
-#: collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.pt:50
+#: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.pt:50
 msgid "description_password_expiration"
 msgstr "Ver e gerenciar as propriedades de expiração das senhas dos usuários"
 
 #. Default: "${days} days left to password expiration"
-#: collective/pwexpiry/utils.py:35
+#: ./collective/pwexpiry/utils.py:35
 msgid "email_subject"
 msgstr "Sua senha vai expirar em ${days} dias"
 
 #. Default: "Hello ${fullname},\n\nThere are ${days} days left before your password expires!\n\nPlease ensure to reset your password before it's expired."
-#: collective/pwexpiry/browser/emails/emails.py:51
+#: ./collective/pwexpiry/browser/emails/emails.py:51
 msgid "email_text"
 msgstr ""
 "Olá ${fullname},\n"
@@ -115,7 +176,7 @@ msgstr ""
 "Por favor altere sua senha antes que isso ocorra."
 
 #. Default: "Hello ${fullname},\n\nYour password has expired.\n\nPlease ensure to reset your password before it's expired."
-#: collective/pwexpiry/browser/emails/emails.py:71
+#: ./collective/pwexpiry/browser/emails/emails.py:71
 msgid "email_text_expired"
 msgstr ""
 "Olá ${fullname},\n"
@@ -125,51 +186,54 @@ msgstr ""
 "Por favor defina uma nova senha."
 
 #. Default: "The date of performing the last notification for the user"
-#: collective/pwexpiry/userdataschema.py:32
+#: ./collective/pwexpiry/userdataschema.py:32
 msgid "help_last_notification_date"
 msgstr "A data da última notificação ao usuário"
 
 #. Default: "The date of setting the password"
-#: collective/pwexpiry/userdataschema.py:22
+#: ./collective/pwexpiry/userdataschema.py:22
 msgid "help_password_date"
 msgstr "A data em que a senha foi alterada"
 
 #. Default: "This password has been used already."
-#: collective/pwexpiry/password_history_validator.py:51
+#: ./collective/pwexpiry/password_history_validator.py:51
 msgid "info_reused_pw"
 msgstr "Essa senha já foi usada."
 
 #. Default: "Apply Changes"
-#: collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.pt:169
+#: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.pt:169
 msgid "label_apply_changes"
 msgstr "Aplicar mudanças"
 
 #. Default: "Last notification date"
-#: collective/pwexpiry/userdataschema.py:29
+#: ./collective/pwexpiry/userdataschema.py:29
 msgid "label_last_notification_date"
 msgstr "Data da última notificação"
 
 #. Default: "Password date"
-#: collective/pwexpiry/userdataschema.py:21
+#: ./collective/pwexpiry/userdataschema.py:21
 msgid "label_password_date"
 msgstr "Data da senha"
 
 #. Default: "Save whitelist"
-#: collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.pt:194
+#: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.pt:194
 msgid "label_save_whitelist"
 msgstr "Guardar lista de ignorados"
 
 #. Default: "Users whitelisted"
-#: collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.pt:189
+#: ./collective/pwexpiry/browser/preferences/pwexpirycontrolpanel.pt:189
 msgid "label_whitelist_users"
 msgstr "Usuários ignorados"
 
 #. Default: "\n\nIn order to reset your password, please visit ${server_url}/mail_password_form?userid=${username}"
-#: collective/pwexpiry/browser/emails/emails.py:83
+#: ./collective/pwexpiry/browser/emails/emails.py:83
 msgid "reset_password_email_text"
-msgstr "Para alterar sua senha visite ${server_url}/mail_password_form?userid=${username}"
+msgstr ""
+"Para alterar sua senha visite ${server_url}/mail_password_form?userid=${userna"
+"me}"
 
 #. Default: "\n\nThis email was sent from ${server_name}"
-#: collective/pwexpiry/browser/emails/emails.py:92
+#: ./collective/pwexpiry/browser/emails/emails.py:92
 msgid "server_name_email_text"
 msgstr "Esta mensagem foi enviada desde ${server_name}"
+

--- a/collective/pwexpiry/pwdisable_plugin.py
+++ b/collective/pwexpiry/pwdisable_plugin.py
@@ -64,7 +64,8 @@ class PwDisablePlugin(BasePlugin):
                     _(u'Login failed. Both email address and password are case '
                       u'sensitive, check that caps lock is not enabled. If you '
                       u'have entered your password correctly, your account might '
-                      u'be locked.'),
+                      u'be locked. You can reset your password, or contact an '
+                      u'administrator to unlock it, using the Contact form.'),
                     type='error'
                 )
             else:
@@ -72,7 +73,8 @@ class PwDisablePlugin(BasePlugin):
                     _(u'Login failed. Both login name and password are case '
                       u'sensitive, check that caps lock is not enabled. If you '
                       u'have entered your password correctly, your account might '
-                      u'be locked.'),
+                      u'be locked. You can reset your password, or contact an '
+                      u'administrator to unlock it, using the Contact form.'),
                     type='error'
                 )
 

--- a/collective/pwexpiry/pwdisable_plugin.py
+++ b/collective/pwexpiry/pwdisable_plugin.py
@@ -53,17 +53,30 @@ class PwDisablePlugin(BasePlugin):
         """
         user_disabled = response.getHeader('user_disabled')
         if user_disabled:
-            user_disabled_time = response.getHeader('user_disabled_time')
-            IStatusMessage(self.REQUEST).add(
-                _(u'Your account has been locked due to too many invalid '
-                  'attempts to login with a wrong password. Your account will '
-                  'remain blocked for the next ${hrs} hours. You can reset your '
-                  'password, or contact an administrator to unlock it, using '
-                  'the Contact form.',
-                  mapping={'hrs': user_disabled_time}),
-                type='error'
-            )
-            response.redirect('login_form', lock=1)
+            if 'plone.use_email_as_login' in self.portal_registry:
+                email_login = self.portal_registry.get('plone.use_email_as_login', False)
+            else:
+                props = self.portal_properties.site_properties
+                email_login = props.getProperty('use_email_as_login')
+
+            if email_login:
+                IStatusMessage(self.REQUEST).add(
+                    _(u'Login failed. Both email address and password are case '
+                      u'sensitive, check that caps lock is not enabled. If you '
+                      u'have entered your password correctly, your account might '
+                      u'be locked.'),
+                    type='error'
+                )
+            else:
+                IStatusMessage(self.REQUEST).add(
+                    _(u'Login failed. Both login name and password are case '
+                      u'sensitive, check that caps lock is not enabled. If you '
+                      u'have entered your password correctly, your account might '
+                      u'be locked.'),
+                    type='error'
+                )
+
+            response.redirect('login_failed', lock=1)
             return 1
         return 0
 

--- a/collective/pwexpiry/skins/pwexpiry/logged_in.cpy
+++ b/collective/pwexpiry/skins/pwexpiry/logged_in.cpy
@@ -1,0 +1,58 @@
+## Controller Python Script "logged_in"
+##bind container=container
+##bind context=context
+##bind namespace=
+##bind script=script
+##bind state=state
+##bind subpath=traverse_subpath
+##parameters=
+##title=Initial post-login actions
+
+from Products.CMFCore.utils import getToolByName
+from collective.pwexpiry.config import _
+
+REQUEST = context.REQUEST
+
+membership_tool = getToolByName(context, 'portal_membership')
+if membership_tool.isAnonymousUser():
+    REQUEST.RESPONSE.expireCookie('__ac', path='/')
+    if 'plone.use_email_as_login' in context.portal_registry:
+        email_login = context.portal_registry['plone.use_email_as_login']
+    else:
+        email_login = getToolByName(context, 'portal_properties') \
+                .site_properties.getProperty('use_email_as_login')
+    if email_login:
+        context.plone_utils.addPortalMessage(
+            _(u'Login failed. Both email address and password are case '
+              u'sensitive, check that caps lock is not enabled. If you '
+              u'have entered your password correctly, your account might '
+              u'be locked.'),
+            'error')
+    else:
+        context.plone_utils.addPortalMessage(
+            _(u'Login failed. Both login name and password are case '
+              u'sensitive, check that caps lock is not enabled. If you '
+              u'have entered your password correctly, your account might '
+              u'be locked.'),
+            'error')
+    return state.set(status='failure')
+
+from DateTime import DateTime
+member = membership_tool.getAuthenticatedMember()
+login_time = member.getProperty('login_time', '2000/01/01')
+if not isinstance(login_time, DateTime):
+    login_time = DateTime(login_time)
+initial_login = int(login_time == DateTime('2000/01/01'))
+state.set(initial_login=initial_login)
+
+must_change_password = member.getProperty('must_change_password', 0)
+state.set(must_change_password=must_change_password)
+
+if initial_login:
+    state.set(status='initial_login')
+elif must_change_password:
+    state.set(status='change_password')
+
+membership_tool.loginUser(REQUEST)
+
+return state

--- a/collective/pwexpiry/skins/pwexpiry/logged_in.cpy
+++ b/collective/pwexpiry/skins/pwexpiry/logged_in.cpy
@@ -26,14 +26,16 @@ if membership_tool.isAnonymousUser():
             _(u'Login failed. Both email address and password are case '
               u'sensitive, check that caps lock is not enabled. If you '
               u'have entered your password correctly, your account might '
-              u'be locked.'),
+              u'be locked. You can reset your password, or contact an '
+              u'administrator to unlock it, using the Contact form.'),
             'error')
     else:
         context.plone_utils.addPortalMessage(
             _(u'Login failed. Both login name and password are case '
               u'sensitive, check that caps lock is not enabled. If you '
               u'have entered your password correctly, your account might '
-              u'be locked.'),
+              u'be locked. You can reset your password, or contact an '
+              u'administrator to unlock it, using the Contact form.'),
             'error')
     return state.set(status='failure')
 

--- a/collective/pwexpiry/skins/pwexpiry/logged_in.cpy.metadata
+++ b/collective/pwexpiry/skins/pwexpiry/logged_in.cpy.metadata
@@ -1,0 +1,5 @@
+[actions]
+action.success=traverse_to:string:login_next
+action.initial_login=traverse_to:string:login_initial
+action.change_password=traverse_to:string:login_password
+action.failure=traverse_to:string:login_failed

--- a/collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy
+++ b/collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy
@@ -1,0 +1,111 @@
+## Script (Python) "validate_login_form"
+##bind container=container
+##bind context=context
+##bind namespace=
+##bind script=script
+##bind state=state
+##bind subpath=traverse_subpath
+##parameters=
+##title=Validate login
+
+from Products.CMFCore.utils import getToolByName
+from collective.pwexpiry.config import _
+
+request = context.REQUEST
+js_enabled = request.get('js_enabled', 0)  # is javascript enabled?
+js_enabled = js_enabled == '1' or js_enabled == 1
+cookies_enabled = request.get('cookies_enabled', 0)  # are cookies enabled?
+cookies_enabled = cookies_enabled == '1' or cookies_enabled == 1
+
+if js_enabled and not cookies_enabled:
+    context.plone_utils.addPortalMessage(
+        _(u'You must enable cookies before you can log in.'), 'error')
+    state.set(status='enable_cookies')
+    return state
+
+mt=context.portal_membership
+if mt.isAnonymousUser():
+    if 'plone.use_email_as_login' in context.portal_registry:
+        email_login = context.portal_registry['plone.use_email_as_login']
+    else:
+        props = getToolByName(context, 'portal_properties').site_properties
+        email_login = props.getProperty('use_email_as_login')
+
+    if js_enabled:  # javascript is enabled - we can diagnose the failure
+        # using cookie authentication?
+        auth = getattr(context, 'cookie_authentication', None)
+        if auth:
+            user_name = request.get('login_name', None)
+            password_empty = request.get('pwd_empty', None) == '1'
+            ac_name = auth.name_cookie
+            ac_password = auth.pw_cookie
+
+            if not user_name:
+                # no user name
+                if email_login:
+                    state.setError(
+                            ac_name,
+                            _(u'Please enter your email address.'),
+                            'email_address_required')
+                else:
+                    state.setError(
+                            ac_name,
+                            _(u'Please enter your login name.'),
+                            'login_name_required')
+            if password_empty:
+                state.setError(
+                        ac_password,
+                        _(u'Please enter your password.'),
+                        'password_required')
+            verify_login_name = context.portal_registry['plone.verify_login_name']
+            if user_name and verify_login_name:
+                # XXX mixing up username and loginname here
+                if mt.getMemberById(user_name) is None:
+                    if email_login:
+                        state.setError(
+                                ac_name,
+                                _(u'Email address not known.'),
+                                'email_address_not_known')
+                    else:
+                        state.setError(
+                                ac_name,
+                                _(u'Login name not found.'),
+                                'login_name_not_found')
+                elif not password_empty:
+                    state.setError(
+                            ac_password,
+                            _(u'Password incorrect.'),
+                            'password_incorrect')
+        if email_login:
+            context.plone_utils.addPortalMessage(
+                _(u'Login failed. Both email address and password are case '
+                  u'sensitive, check that caps lock is not enabled. If you '
+                  u'have entered your password correctly, your account might '
+                  u'be locked.'),
+                'error')
+        else:
+            context.plone_utils.addPortalMessage(
+                _(u'Login failed. Both login name and password are case '
+                  u'sensitive, check that caps lock is not enabled. If you '
+                  u'have entered your password correctly, your account might '
+                  u'be locked.'),
+                'error')
+        state.set(status='failure')
+    else:  # no javascript - do low tech login failure
+        if email_login:
+            context.plone_utils.addPortalMessage(
+                _(u'Login failed. Both email address and password are case '
+                  u'sensitive, check that caps lock is not enabled. If you '
+                  u'have entered your password correctly, your account might '
+                  u'be locked.'),
+                'error')
+        else:
+            context.plone_utils.addPortalMessage(
+                _(u'Login failed. Both login name and password are case '
+                  u'sensitive, check that caps lock is not enabled. If you '
+                  u'have entered your password correctly, your account might '
+                  u'be locked.'),
+                'error')
+        state.set(status='failure_page')
+
+return state

--- a/collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy
+++ b/collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy
@@ -9,6 +9,7 @@
 ##title=Validate login
 
 from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone import PloneMessageFactory as PMF
 from collective.pwexpiry.config import _
 
 request = context.REQUEST
@@ -19,7 +20,7 @@ cookies_enabled = cookies_enabled == '1' or cookies_enabled == 1
 
 if js_enabled and not cookies_enabled:
     context.plone_utils.addPortalMessage(
-        _(u'You must enable cookies before you can log in.'), 'error')
+        PMF(u'You must enable cookies before you can log in.'), 'error')
     state.set(status='enable_cookies')
     return state
 
@@ -45,17 +46,17 @@ if mt.isAnonymousUser():
                 if email_login:
                     state.setError(
                             ac_name,
-                            _(u'Please enter your email address.'),
+                            PMF(u'Please enter your email address.'),
                             'email_address_required')
                 else:
                     state.setError(
                             ac_name,
-                            _(u'Please enter your login name.'),
+                            PMF(u'Please enter your login name.'),
                             'login_name_required')
             if password_empty:
                 state.setError(
                         ac_password,
-                        _(u'Please enter your password.'),
+                        PMF(u'Please enter your password.'),
                         'password_required')
             verify_login_name = context.portal_registry['plone.verify_login_name']
             if user_name and verify_login_name:
@@ -64,17 +65,17 @@ if mt.isAnonymousUser():
                     if email_login:
                         state.setError(
                                 ac_name,
-                                _(u'Email address not known.'),
+                                PMF(u'Email address not known.'),
                                 'email_address_not_known')
                     else:
                         state.setError(
                                 ac_name,
-                                _(u'Login name not found.'),
+                                PMF(u'Login name not found.'),
                                 'login_name_not_found')
                 elif not password_empty:
                     state.setError(
                             ac_password,
-                            _(u'Password incorrect.'),
+                            PMF(u'Password incorrect.'),
                             'password_incorrect')
         if email_login:
             context.plone_utils.addPortalMessage(

--- a/collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy
+++ b/collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy
@@ -81,14 +81,16 @@ if mt.isAnonymousUser():
                 _(u'Login failed. Both email address and password are case '
                   u'sensitive, check that caps lock is not enabled. If you '
                   u'have entered your password correctly, your account might '
-                  u'be locked.'),
+                  u'be locked. You can reset your password, or contact an '
+                  u'administrator to unlock it, using the Contact form.'),
                 'error')
         else:
             context.plone_utils.addPortalMessage(
                 _(u'Login failed. Both login name and password are case '
                   u'sensitive, check that caps lock is not enabled. If you '
                   u'have entered your password correctly, your account might '
-                  u'be locked.'),
+                  u'be locked. You can reset your password, or contact an '
+                  u'administrator to unlock it, using the Contact form.'),
                 'error')
         state.set(status='failure')
     else:  # no javascript - do low tech login failure
@@ -97,14 +99,16 @@ if mt.isAnonymousUser():
                 _(u'Login failed. Both email address and password are case '
                   u'sensitive, check that caps lock is not enabled. If you '
                   u'have entered your password correctly, your account might '
-                  u'be locked.'),
+                  u'be locked. You can reset your password, or contact an '
+                  u'administrator to unlock it, using the Contact form.'),
                 'error')
         else:
             context.plone_utils.addPortalMessage(
                 _(u'Login failed. Both login name and password are case '
                   u'sensitive, check that caps lock is not enabled. If you '
                   u'have entered your password correctly, your account might '
-                  u'be locked.'),
+                  u'be locked. You can reset your password, or contact an '
+                  u'administrator to unlock it, using the Contact form.'),
                 'error')
         state.set(status='failure_page')
 

--- a/collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy.metadata
+++ b/collective/pwexpiry/skins/pwexpiry/login_form_validate.vpy.metadata
@@ -1,0 +1,3 @@
+[default]
+proxy=Manager
+

--- a/collective/pwexpiry/testing.py
+++ b/collective/pwexpiry/testing.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from plone.app.robotframework.testing import AUTOLOGIN_LIBRARY_FIXTURE
 from plone.app.testing import applyProfile
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
@@ -8,6 +9,7 @@ from plone.app.testing import PloneSandboxLayer
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
+from plone.testing import z2
 
 import unittest
 
@@ -55,6 +57,9 @@ INTEGRATION_TESTING = IntegrationTesting(
     bases=(FIXTURE,), name="PwExpiryLayer:Integration")
 FUNCTIONAL_TESTING = FunctionalTesting(
     bases=(FIXTURE,), name="PwExpiryLayer:Functional")
+ROBOT_TESTING = FunctionalTesting(
+    bases=(FIXTURE, AUTOLOGIN_LIBRARY_FIXTURE, z2.ZSERVER_FIXTURE),
+    name='PwExpiryLayer:Robot')
 
 
 class IntegrationTestCase(unittest.TestCase):

--- a/collective/pwexpiry/tests/pwexpiryp4.robot
+++ b/collective/pwexpiry/tests/pwexpiryp4.robot
@@ -8,7 +8,7 @@ Variables  plone/app/testing/interfaces.py
 ${PORT} =  55001
 ${ZOPE_URL} =  http://localhost:${PORT}
 ${PLONE_URL} =  ${ZOPE_URL}/plone
-${BROWSER} =  Chrome
+${BROWSER} =  Firefox
 
 *** Keywords ***
 

--- a/collective/pwexpiry/tests/pwexpiryp4.robot
+++ b/collective/pwexpiry/tests/pwexpiryp4.robot
@@ -48,6 +48,7 @@ Setup PWexpiry Use Username Login
     Input Text  id=q  validity_period
     Click Button  Filter
     Click Link  collective pwexpiry validity_period
+    Wait Until Element Is Visible  id=form-widgets-value
     Input Text  id=form-widgets-value  0
     Click Button  id=form-buttons-save
     Go to Users and Groups
@@ -70,6 +71,7 @@ Setup PWexpiry Use Email Login
     Input Text  id=q  validity_period
     Click Button  Filter
     Click Link  collective pwexpiry validity_period
+    Wait Until Element Is Visible  id=form-widgets-value
     Input Text  id=form-widgets-value  0
     Click Button  id=form-buttons-save
     Go to Users and Groups

--- a/collective/pwexpiry/tests/pwexpiryp4.robot
+++ b/collective/pwexpiry/tests/pwexpiryp4.robot
@@ -1,0 +1,83 @@
+*** Settings ***
+
+Resource  plone/app/robotframework/keywords.robot
+Variables  plone/app/testing/interfaces.py
+
+*** Variables ***
+
+${PORT} =  55001
+${ZOPE_URL} =  http://localhost:${PORT}
+${PLONE_URL} =  ${ZOPE_URL}/plone
+${BROWSER} =  Chrome
+
+*** Keywords ***
+
+Start Browser and Autologin as
+    [arguments]  ${role}
+
+    Open Test Browser
+    Enable Autologin as  $role
+
+Start Browser and Log In as Site Owner
+    Open Test Browser
+    Log In As Site Owner
+    Click Link  link=Home
+
+Go to Site Setup
+    Go to   ${PLONE_URL}/@@overview-controlpanel
+    Wait until location is  ${PLONE_URL}/@@overview-controlpanel
+
+Go to Security Settings
+    Go to   ${PLONE_URL}/@@security-controlpanel
+    Wait until location is  ${PLONE_URL}/@@security-controlpanel
+
+Go to Users and Groups
+    Go to   ${PLONE_URL}/@@usergroup-userprefs
+    Wait until location is  ${PLONE_URL}/@@usergroup-userprefs
+
+Go to Configuration Registry
+    Go to   ${PLONE_URL}/portal_registry
+    Wait until location is  ${PLONE_URL}/portal_registry
+
+Setup PWexpiry Use Username Login
+    Start Browser and Log In as Site Owner
+    Go to Security Settings
+    Select Checkbox  id=form.enable_user_pwd_choice
+    Click Button  id=form.actions.save
+    Go to Configuration Registry
+    Input Text  id=q  validity_period
+    Click Button  Filter
+    Click Link  collective pwexpiry validity_period
+    Input Text  id=form-widgets-value  0
+    Click Button  id=form-buttons-save
+    Go to Users and Groups
+    Click Button  name=form.button.AddUser
+    Input Text  id=form.fullname  Test User 1
+    Input Text  id=form.username  test_user_1
+    Input Text  id=form.email  test_user_1@none.com
+    Input Text  id=form.password  test_user_1
+    Input Text  id=form.password_ctl  test_user_1
+    Click Button  id=form.actions.register
+    Log out
+
+Setup PWexpiry Use Email Login
+    Start Browser and Log In as Site Owner
+    Go to Security Settings
+    Select Checkbox  id=form.enable_user_pwd_choice
+    Select Checkbox  id=form.use_email_as_login
+    Click Button  id=form.actions.save
+    Go to Configuration Registry
+    Input Text  id=q  validity_period
+    Click Button  Filter
+    Click Link  collective pwexpiry validity_period
+    Input Text  id=form-widgets-value  0
+    Click Button  id=form-buttons-save
+    Go to Users and Groups
+    Click Button  name=form.button.AddUser
+    Input Text  id=form.fullname  Test User 1
+    Input Text  id=form.email  test_user_1@none.com
+    Input Text  id=form.password  test_user_1
+    Input Text  id=form.password_ctl  test_user_1
+    Click Button  id=form.actions.register
+    Log out
+

--- a/collective/pwexpiry/tests/pwexpiryp5.robot
+++ b/collective/pwexpiry/tests/pwexpiryp5.robot
@@ -5,8 +5,7 @@ Variables  plone/app/testing/interfaces.py
 
 *** Variables ***
 
-${PORT} =  55001
-${ZOPE_URL} =  http://localhost:${PORT}
+${ZOPE_URL} =  http://${ZOPE_HOST}:${ZOPE_PORT}
 ${PLONE_URL} =  ${ZOPE_URL}/plone
 ${BROWSER} =  Firefox
 

--- a/collective/pwexpiry/tests/pwexpiryp5.robot
+++ b/collective/pwexpiry/tests/pwexpiryp5.robot
@@ -8,7 +8,7 @@ Variables  plone/app/testing/interfaces.py
 ${PORT} =  55001
 ${ZOPE_URL} =  http://localhost:${PORT}
 ${PLONE_URL} =  ${ZOPE_URL}/plone
-${BROWSER} =  Chrome
+${BROWSER} =  Firefox
 
 *** Keywords ***
 

--- a/collective/pwexpiry/tests/pwexpiryp5.robot
+++ b/collective/pwexpiry/tests/pwexpiryp5.robot
@@ -1,0 +1,93 @@
+*** Settings ***
+
+Resource  plone/app/robotframework/keywords.robot
+Variables  plone/app/testing/interfaces.py
+
+*** Variables ***
+
+${PORT} =  55001
+${ZOPE_URL} =  http://localhost:${PORT}
+${PLONE_URL} =  ${ZOPE_URL}/plone
+${BROWSER} =  Chrome
+
+*** Keywords ***
+
+Start Browser and Autologin as
+    [arguments]  ${role}
+
+    Open Test Browser
+    Enable Autologin as  $role
+
+Start Browser and Log In as Site Owner
+    Open Test Browser
+    Log In As Site Owner
+    Click Link  link=Home
+
+Go to Site Setup
+    Go to   ${PLONE_URL}/@@overview-controlpanel
+    Wait until location is  ${PLONE_URL}/@@overview-controlpanel
+
+Go to Security Settings
+    Go to   ${PLONE_URL}/@@security-controlpanel
+    Wait until location is  ${PLONE_URL}/@@security-controlpanel
+
+Go to Users and Groups
+    Go to   ${PLONE_URL}/@@usergroup-userprefs
+    Wait until location is  ${PLONE_URL}/@@usergroup-userprefs
+
+Go to Configuration Registry
+    Go to   ${PLONE_URL}/portal_registry
+    Wait until location is  ${PLONE_URL}/portal_registry
+
+Setup PWexpiry Use Username Login
+    Start Browser and Log In as Site Owner
+    Go to Security Settings
+    Select Checkbox  id=form-widgets-enable_user_pwd_choice-0
+    Click Button  id=form-buttons-save
+    Go to Configuration Registry
+    Input Text  id=q  validity_period
+    Press Key  id=q  \\13
+    Wait Until Element Is Not Visible  css:div#plone-loader
+    Click Link  collective pwexpiry validity_period
+    Wait Until Element Is Not Visible  css:div#plone-loader
+    Input Text  id=form-widgets-value  0
+    Press Key  id=form-widgets-value  \\13
+    Wait Until Element Is Not Visible  css:div#plone-loader
+    Go to Users and Groups
+    Click Button  id=add-new-user
+    Wait Until Element Is Not Visible  css:div#plone-loader
+    Input Text  id=form-widgets-fullname  Test User 1
+    Input Text  id=form-widgets-email  test_user_1@none.com
+    Input Text  id=form-widgets-username  test_user_1
+    Input Text  id=form-widgets-password  test_user_1
+    Input Text  id=form-widgets-password_ctl  test_user_1
+    Press Key  id=form-widgets-password_ctl  \\13
+    Wait Until Element Is Not Visible  css:div#plone-loader
+    Log out
+
+Setup PWexpiry Use Email Login
+    Start Browser and Log In as Site Owner
+    Go to Security Settings
+    Select Checkbox  id=form-widgets-enable_user_pwd_choice-0
+    Select Checkbox  id=form-widgets-use_email_as_login-0
+    Click Button  id=form-buttons-save
+    Go to Configuration Registry
+    Input Text  id=q  validity_period
+    Press Key  id=q  \\13
+    Wait Until Element Is Not Visible  css:div#plone-loader
+    Click Link  collective pwexpiry validity_period
+    Wait Until Element Is Not Visible  css:div#plone-loader
+    Input Text  id=form-widgets-value  0
+    Press Key  id=form-widgets-value  \\13
+    Wait Until Element Is Not Visible  css:div#plone-loader
+    Go to Users and Groups
+    Click Button  id=add-new-user
+    Wait Until Element Is Not Visible  css:div#plone-loader
+    Input Text  id=form-widgets-fullname  Test User 1
+    Input Text  id=form-widgets-email  test_user_1@none.com
+    Input Text  id=form-widgets-password  test_user_1
+    Input Text  id=form-widgets-password_ctl  test_user_1
+    Press Key  id=form-widgets-password_ctl  \\13
+    Wait Until Element Is Not Visible  css:div#plone-loader
+    Log out
+

--- a/collective/pwexpiry/tests/test_robot.py
+++ b/collective/pwexpiry/tests/test_robot.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from collective.pwexpiry.config import IS_PLONE_5
+# from collective.pwexpiry.config import PROJECTNAME
+# from collective.pwexpiry.interfaces import ICollectivePWExpiryLayer
+from collective.pwexpiry.testing import ROBOT_TESTING
+
+from plone.testing import layered
+
+import os
+import robotsuite
+import unittest
+
+
+dirname = os.path.dirname(__file__)
+files = os.listdir(dirname)
+if IS_PLONE_5:
+    tests = [f for f in files if f.startswith('test_') and f.endswith('p5.robot')]
+else:
+    tests = [f for f in files if f.startswith('test_') and f.endswith('p4.robot')]
+
+
+def test_suite():
+    suite = unittest.TestSuite()
+    suite.addTests([
+        layered(
+            robotsuite.RobotTestSuite(t,),
+            layer=ROBOT_TESTING)
+        for t in tests
+    ])
+    return suite

--- a/collective/pwexpiry/tests/test_user_locked_p4.robot
+++ b/collective/pwexpiry/tests/test_user_locked_p4.robot
@@ -15,78 +15,54 @@ ${wrong_pw_username_error_msg} =  Login failed. Both login name and password are
 
 Test Username Error Message With Wrong Password
     Setup PWexpiry Use Username Login
-    Input Text  id=__ac_name  test_user_1
-    Input Text  id=__ac_password  test_user_1
-    Click Button  Log in
+    Log in  test_user_1  test_user_1
     Page Should Contain  You are now logged in
     Page Should Not Contain  ${wrong_pw_username_error_msg}
     Log out
 
-    Input Text  id=__ac_name  test_user_1
-    Input Text  id=__ac_password  wrong_pw
-    Click Button  Log in
+    Log in  test_user_1  wrong_pw
     Page Should Not Contain  You are now logged in
     Page Should Contain  ${wrong_pw_username_error_msg}
 
-    Input Text  id=__ac_name  test_user_1
-    Input Text  id=__ac_password  wrong_pw
-    Click Button  Log in
+    Log in  test_user_1  wrong_pw
     Page Should Not Contain  You are now logged in
     Page Should Contain  ${wrong_pw_username_error_msg}
 
-    Input Text  id=__ac_name  test_user_1
-    Input Text  id=__ac_password  wrong_pw
-    Click Button  Log in
+    Log in  test_user_1  wrong_pw
     Page Should Not Contain  You are now logged in
     Page Should Contain  ${wrong_pw_username_error_msg}
 
-    Input Text  id=__ac_name  test_user_1
-    Input Text  id=__ac_password  wrong_pw
-    Click Button  Log in
+    Log in  test_user_1  wrong_pw
     Page Should Not Contain  You are now logged in
     Page Should Contain  ${wrong_pw_username_error_msg}
 
-    Input Text  id=__ac_name  test_user_1
-    Input Text  id=__ac_password  test_user_1
-    Click Button  Log in
+    Log in  test_user_1  test_user_1
     Page Should Not Contain  You are now logged in
     Page Should Contain  ${wrong_pw_username_error_msg}
 
 Test Email Error Message With Wrong Password
     Setup PWexpiry Use Email Login
-    Input Text  id=__ac_name  test_user_1@none.com
-    Input Text  id=__ac_password  test_user_1
-    Click Button  Log in
+    Log in  test_user_1@none.com  test_user_1
     Page Should Contain  You are now logged in
     Page Should Not Contain  ${wrong_pw_email_error_msg}
     Log out
 
-    Input Text  id=__ac_name  test_user_1@none.com
-    Input Text  id=__ac_password  wrong_pw
-    Click Button  Log in
+    Log in  test_user_1@none.com  wrong_pw
     Page Should Not Contain  You are now logged in
     Page Should Contain  ${wrong_pw_email_error_msg}
 
-    Input Text  id=__ac_name  test_user_1@none.com
-    Input Text  id=__ac_password  wrong_pw
-    Click Button  Log in
+    Log in  test_user_1@none.com  wrong_pw
     Page Should Not Contain  You are now logged in
     Page Should Contain  ${wrong_pw_email_error_msg}
 
-    Input Text  id=__ac_name  test_user_1@none.com
-    Input Text  id=__ac_password  wrong_pw
-    Click Button  Log in
+    Log in  test_user_1@none.com  wrong_pw
     Page Should Not Contain  You are now logged in
     Page Should Contain  ${wrong_pw_email_error_msg}
 
-    Input Text  id=__ac_name  test_user_1@none.com
-    Input Text  id=__ac_password  wrong_pw
-    Click Button  Log in
+    Log in  test_user_1@none.com  wrong_pw
     Page Should Not Contain  You are now logged in
     Page Should Contain  ${wrong_pw_email_error_msg}
 
-    Input Text  id=__ac_name  test_user_1@none.com
-    Input Text  id=__ac_password  test_user_1
-    Click Button  Log in
+    Log in  test_user_1@none.com  test_user_1
     Page Should Not Contain  You are now logged in
     Page Should Contain  ${wrong_pw_email_error_msg}

--- a/collective/pwexpiry/tests/test_user_locked_p4.robot
+++ b/collective/pwexpiry/tests/test_user_locked_p4.robot
@@ -1,0 +1,92 @@
+*** Settings ***
+
+Resource  pwexpiryp4.robot
+Library  Remote  ${PLONE_URL}/RobotRemote
+
+Suite Setup  Open Test Browser
+Suite Teardown  Close all browsers
+
+*** Variables ***
+
+${wrong_pw_email_error_msg} =  Login failed. Both email address and password are case sensitive, check that caps lock is not enabled. If you have entered your password correctly, your account might be locked. You can reset your password, or contact an administrator to unlock it, using the Contact form.
+${wrong_pw_username_error_msg} =  Login failed. Both login name and password are case sensitive, check that caps lock is not enabled. If you have entered your password correctly, your account might be locked. You can reset your password, or contact an administrator to unlock it, using the Contact form.
+
+*** Test cases ***
+
+Test Username Error Message With Wrong Password
+    Setup PWexpiry Use Username Login
+    Input Text  id=__ac_name  test_user_1
+    Input Text  id=__ac_password  test_user_1
+    Click Button  Log in
+    Page Should Contain  You are now logged in
+    Page Should Not Contain  ${wrong_pw_username_error_msg}
+    Log out
+
+    Input Text  id=__ac_name  test_user_1
+    Input Text  id=__ac_password  wrong_pw
+    Click Button  Log in
+    Page Should Not Contain  You are now logged in
+    Page Should Contain  ${wrong_pw_username_error_msg}
+
+    Input Text  id=__ac_name  test_user_1
+    Input Text  id=__ac_password  wrong_pw
+    Click Button  Log in
+    Page Should Not Contain  You are now logged in
+    Page Should Contain  ${wrong_pw_username_error_msg}
+
+    Input Text  id=__ac_name  test_user_1
+    Input Text  id=__ac_password  wrong_pw
+    Click Button  Log in
+    Page Should Not Contain  You are now logged in
+    Page Should Contain  ${wrong_pw_username_error_msg}
+
+    Input Text  id=__ac_name  test_user_1
+    Input Text  id=__ac_password  wrong_pw
+    Click Button  Log in
+    Page Should Not Contain  You are now logged in
+    Page Should Contain  ${wrong_pw_username_error_msg}
+
+    Input Text  id=__ac_name  test_user_1
+    Input Text  id=__ac_password  test_user_1
+    Click Button  Log in
+    Page Should Not Contain  You are now logged in
+    Page Should Contain  ${wrong_pw_username_error_msg}
+
+Test Email Error Message With Wrong Password
+    Setup PWexpiry Use Email Login
+    Input Text  id=__ac_name  test_user_1@none.com
+    Input Text  id=__ac_password  test_user_1
+    Click Button  Log in
+    Page Should Contain  You are now logged in
+    Page Should Not Contain  ${wrong_pw_email_error_msg}
+    Log out
+
+    Input Text  id=__ac_name  test_user_1@none.com
+    Input Text  id=__ac_password  wrong_pw
+    Click Button  Log in
+    Page Should Not Contain  You are now logged in
+    Page Should Contain  ${wrong_pw_email_error_msg}
+
+    Input Text  id=__ac_name  test_user_1@none.com
+    Input Text  id=__ac_password  wrong_pw
+    Click Button  Log in
+    Page Should Not Contain  You are now logged in
+    Page Should Contain  ${wrong_pw_email_error_msg}
+
+    Input Text  id=__ac_name  test_user_1@none.com
+    Input Text  id=__ac_password  wrong_pw
+    Click Button  Log in
+    Page Should Not Contain  You are now logged in
+    Page Should Contain  ${wrong_pw_email_error_msg}
+
+    Input Text  id=__ac_name  test_user_1@none.com
+    Input Text  id=__ac_password  wrong_pw
+    Click Button  Log in
+    Page Should Not Contain  You are now logged in
+    Page Should Contain  ${wrong_pw_email_error_msg}
+
+    Input Text  id=__ac_name  test_user_1@none.com
+    Input Text  id=__ac_password  test_user_1
+    Click Button  Log in
+    Page Should Not Contain  You are now logged in
+    Page Should Contain  ${wrong_pw_email_error_msg}

--- a/collective/pwexpiry/tests/test_user_locked_p5.robot
+++ b/collective/pwexpiry/tests/test_user_locked_p5.robot
@@ -15,78 +15,54 @@ ${wrong_pw_username_error_msg} =  Login failed. Both login name and password are
 
 Test Username Error Message With Wrong Password
     Setup PWexpiry Use Username Login
-    Input Text  id=__ac_name  test_user_1
-    Input Text  id=__ac_password  test_user_1
-    Click Button  Log in
+    Log in  test_user_1  test_user_1
     Page Should Contain  You are now logged in
     Page Should Not Contain  ${wrong_pw_username_error_msg}
     Log out
 
-    Input Text  id=__ac_name  test_user_1
-    Input Text  id=__ac_password  wrong_pw
-    Click Button  Log in
+    Log in  test_user_1  wrong_pw
     Page Should Not Contain  You are now logged in
     Page Should Contain  ${wrong_pw_username_error_msg}
 
-    Input Text  id=__ac_name  test_user_1
-    Input Text  id=__ac_password  wrong_pw
-    Click Button  Log in
+    Log in  test_user_1  wrong_pw
     Page Should Not Contain  You are now logged in
     Page Should Contain  ${wrong_pw_username_error_msg}
 
-    Input Text  id=__ac_name  test_user_1
-    Input Text  id=__ac_password  wrong_pw
-    Click Button  Log in
+    Log in  test_user_1  wrong_pw
     Page Should Not Contain  You are now logged in
     Page Should Contain  ${wrong_pw_username_error_msg}
 
-    Input Text  id=__ac_name  test_user_1
-    Input Text  id=__ac_password  wrong_pw
-    Click Button  Log in
+    Log in  test_user_1  wrong_pw
     Page Should Not Contain  You are now logged in
     Page Should Contain  ${wrong_pw_username_error_msg}
 
-    Input Text  id=__ac_name  test_user_1
-    Input Text  id=__ac_password  test_user_1
-    Click Button  Log in
+    Log in  test_user_1  test_user_1
     Page Should Not Contain  You are now logged in
     Page Should Contain  ${wrong_pw_username_error_msg}
 
 Test Email Error Message With Wrong Password
     Setup PWexpiry Use Email Login
-    Input Text  id=__ac_name  test_user_1@none.com
-    Input Text  id=__ac_password  test_user_1
-    Click Button  Log in
+    Log in  test_user_1@none.com  test_user_1
     Page Should Contain  You are now logged in
     Page Should Not Contain  ${wrong_pw_email_error_msg}
     Log out
 
-    Input Text  id=__ac_name  test_user_1@none.com
-    Input Text  id=__ac_password  wrong_pw
-    Click Button  Log in
+    Log in  test_user_1@none.com  wrong_pw
     Page Should Not Contain  You are now logged in
     Page Should Contain  ${wrong_pw_email_error_msg}
 
-    Input Text  id=__ac_name  test_user_1@none.com
-    Input Text  id=__ac_password  wrong_pw
-    Click Button  Log in
+    Log in  test_user_1@none.com  wrong_pw
     Page Should Not Contain  You are now logged in
     Page Should Contain  ${wrong_pw_email_error_msg}
 
-    Input Text  id=__ac_name  test_user_1@none.com
-    Input Text  id=__ac_password  wrong_pw
-    Click Button  Log in
+    Log in  test_user_1@none.com  wrong_pw
     Page Should Not Contain  You are now logged in
     Page Should Contain  ${wrong_pw_email_error_msg}
 
-    Input Text  id=__ac_name  test_user_1@none.com
-    Input Text  id=__ac_password  wrong_pw
-    Click Button  Log in
+    Log in  test_user_1@none.com  wrong_pw
     Page Should Not Contain  You are now logged in
     Page Should Contain  ${wrong_pw_email_error_msg}
 
-    Input Text  id=__ac_name  test_user_1@none.com
-    Input Text  id=__ac_password  test_user_1
-    Click Button  Log in
+    Log in  test_user_1@none.com  test_user_1
     Page Should Not Contain  You are now logged in
     Page Should Contain  ${wrong_pw_email_error_msg}

--- a/collective/pwexpiry/tests/test_user_locked_p5.robot
+++ b/collective/pwexpiry/tests/test_user_locked_p5.robot
@@ -1,0 +1,92 @@
+*** Settings ***
+
+Resource  pwexpiryp5.robot
+Library  Remote  ${PLONE_URL}/RobotRemote
+
+Suite Setup  Open Test Browser
+Suite Teardown  Close all browsers
+
+*** Variables ***
+
+${wrong_pw_email_error_msg} =  Login failed. Both email address and password are case sensitive, check that caps lock is not enabled. If you have entered your password correctly, your account might be locked. You can reset your password, or contact an administrator to unlock it, using the Contact form.
+${wrong_pw_username_error_msg} =  Login failed. Both login name and password are case sensitive, check that caps lock is not enabled. If you have entered your password correctly, your account might be locked. You can reset your password, or contact an administrator to unlock it, using the Contact form.
+
+*** Test cases ***
+
+Test Username Error Message With Wrong Password
+    Setup PWexpiry Use Username Login
+    Input Text  id=__ac_name  test_user_1
+    Input Text  id=__ac_password  test_user_1
+    Click Button  Log in
+    Page Should Contain  You are now logged in
+    Page Should Not Contain  ${wrong_pw_username_error_msg}
+    Log out
+
+    Input Text  id=__ac_name  test_user_1
+    Input Text  id=__ac_password  wrong_pw
+    Click Button  Log in
+    Page Should Not Contain  You are now logged in
+    Page Should Contain  ${wrong_pw_username_error_msg}
+
+    Input Text  id=__ac_name  test_user_1
+    Input Text  id=__ac_password  wrong_pw
+    Click Button  Log in
+    Page Should Not Contain  You are now logged in
+    Page Should Contain  ${wrong_pw_username_error_msg}
+
+    Input Text  id=__ac_name  test_user_1
+    Input Text  id=__ac_password  wrong_pw
+    Click Button  Log in
+    Page Should Not Contain  You are now logged in
+    Page Should Contain  ${wrong_pw_username_error_msg}
+
+    Input Text  id=__ac_name  test_user_1
+    Input Text  id=__ac_password  wrong_pw
+    Click Button  Log in
+    Page Should Not Contain  You are now logged in
+    Page Should Contain  ${wrong_pw_username_error_msg}
+
+    Input Text  id=__ac_name  test_user_1
+    Input Text  id=__ac_password  test_user_1
+    Click Button  Log in
+    Page Should Not Contain  You are now logged in
+    Page Should Contain  ${wrong_pw_username_error_msg}
+
+Test Email Error Message With Wrong Password
+    Setup PWexpiry Use Email Login
+    Input Text  id=__ac_name  test_user_1@none.com
+    Input Text  id=__ac_password  test_user_1
+    Click Button  Log in
+    Page Should Contain  You are now logged in
+    Page Should Not Contain  ${wrong_pw_email_error_msg}
+    Log out
+
+    Input Text  id=__ac_name  test_user_1@none.com
+    Input Text  id=__ac_password  wrong_pw
+    Click Button  Log in
+    Page Should Not Contain  You are now logged in
+    Page Should Contain  ${wrong_pw_email_error_msg}
+
+    Input Text  id=__ac_name  test_user_1@none.com
+    Input Text  id=__ac_password  wrong_pw
+    Click Button  Log in
+    Page Should Not Contain  You are now logged in
+    Page Should Contain  ${wrong_pw_email_error_msg}
+
+    Input Text  id=__ac_name  test_user_1@none.com
+    Input Text  id=__ac_password  wrong_pw
+    Click Button  Log in
+    Page Should Not Contain  You are now logged in
+    Page Should Contain  ${wrong_pw_email_error_msg}
+
+    Input Text  id=__ac_name  test_user_1@none.com
+    Input Text  id=__ac_password  wrong_pw
+    Click Button  Log in
+    Page Should Not Contain  You are now logged in
+    Page Should Contain  ${wrong_pw_email_error_msg}
+
+    Input Text  id=__ac_name  test_user_1@none.com
+    Input Text  id=__ac_password  test_user_1
+    Click Button  Log in
+    Page Should Not Contain  You are now logged in
+    Page Should Contain  ${wrong_pw_email_error_msg}

--- a/setup.py
+++ b/setup.py
@@ -39,9 +39,20 @@ setup(name='collective.pwexpiry',
           'collective.monkeypatcher',
       ],
       extras_require={
-          "test": [
-              "Plone",
-              "plone.app.testing",
+          'test': [
+              'cssselect',
+              'lxml',
+              'mock',
+              'plone.api >=1.8.5',
+              'plone.app.robotframework',
+              'plone.app.testing [robot]',
+              'plone.browserlayer',
+              'plone.cachepurging',
+              'plone.testing',
+              'robotsuite',
+              'testfixtures',
+              'transaction',
+              'tzlocal',
           ],
       },
       entry_points="""

--- a/test-4.3.x.cfg
+++ b/test-4.3.x.cfg
@@ -18,6 +18,10 @@ pyroma = 2.4
 readme-renderer = 24.0
 tqdm = 4.28.1
 urllib3 = 1.22
+plone.api = 1.8.5
+cssselect = 1.0.1
+testfixtures = 4.13.4
+tzlocal = 1.5.1
 
 # Required by:
 # zest.releaser==6.13.5

--- a/test-4.3.x.cfg
+++ b/test-4.3.x.cfg
@@ -1,0 +1,28 @@
+[buildout]
+extends =
+    https://raw.github.com/collective/buildout.plonetest/master/test-4.3.x.cfg
+
+[versions]
+setuptools = 40.5.0
+zc.buildout = 2.12.2
+plone.recipe.zope2instance = 4.4.1
+docutils = 0.14
+Products.PrintingMailHost = 1.1.0
+bleach = 3.0.2
+certifi = 2018.10.15
+chardet = 3.0.4
+check-manifest = 0.37
+idna = 2.6
+pkginfo = 1.4.2
+pyroma = 2.4
+readme-renderer = 24.0
+tqdm = 4.28.1
+urllib3 = 1.22
+
+# Required by:
+# zest.releaser==6.13.5
+colorama = 0.4.0
+
+# Required by:
+# bleach==3.0.2
+webencodings = 0.5.1

--- a/test-5.0.x.cfg
+++ b/test-5.0.x.cfg
@@ -1,0 +1,25 @@
+[buildout]
+extends =
+    https://raw.github.com/collective/buildout.plonetest/master/test-5.0.x.cfg
+
+[versions]
+setuptools = 40.5.0
+zc.buildout = 2.12.2
+plone.recipe.zope2instance = 4.4.1
+docutils = 0.14
+Products.PrintingMailHost = 1.1.0
+bleach = 3.0.2
+chardet = 3.0.4
+check-manifest = 0.37
+pkginfo = 1.4.2
+pyroma = 2.4
+readme-renderer = 24.0
+requests-toolbelt = 0.8.0
+
+# Required by:
+# zest.releaser==6.9
+colorama = 0.4.0
+
+# Required by:
+# bleach==3.0.2
+webencodings = 0.5.1

--- a/test-5.0.x.cfg
+++ b/test-5.0.x.cfg
@@ -18,6 +18,7 @@ requests-toolbelt = 0.8.0
 plone.api = 1.8.5
 testfixtures = 4.13.4
 tzlocal = 1.5.1
+plone.app.robotframework = 1.4.0
 
 # Required by:
 # zest.releaser==6.9

--- a/test-5.0.x.cfg
+++ b/test-5.0.x.cfg
@@ -15,6 +15,9 @@ pkginfo = 1.4.2
 pyroma = 2.4
 readme-renderer = 24.0
 requests-toolbelt = 0.8.0
+plone.api = 1.8.5
+testfixtures = 4.13.4
+tzlocal = 1.5.1
 
 # Required by:
 # zest.releaser==6.9

--- a/test-5.1.x.cfg
+++ b/test-5.1.x.cfg
@@ -1,0 +1,25 @@
+[buildout]
+extends =
+    https://raw.github.com/collective/buildout.plonetest/master/test-5.1.x.cfg
+
+[versions]
+setuptools = 40.5.0
+zc.buildout = 2.12.2
+plone.recipe.zope2instance = 4.4.1
+Products.PrintingMailHost = 1.1.0
+bleach = 3.0.2
+chardet = 3.0.4
+check-manifest = 0.37
+idna = 2.6
+pkginfo = 1.4.2
+pyroma = 2.4
+readme-renderer = 24.0
+requests-toolbelt = 0.8.0
+
+# Required by:
+# zest.releaser==6.15.0
+colorama = 0.4.0
+
+# Required by:
+# bleach==3.0.2
+webencodings = 0.5.1

--- a/test-5.1.x.cfg
+++ b/test-5.1.x.cfg
@@ -18,6 +18,7 @@ requests-toolbelt = 0.8.0
 pbr = 5.1.1
 testfixtures = 4.13.4
 tzlocal = 1.5.1
+plone.app.robotframework = 1.4.0
 
 # Required by:
 # zest.releaser==6.15.0

--- a/test-5.1.x.cfg
+++ b/test-5.1.x.cfg
@@ -15,6 +15,9 @@ pkginfo = 1.4.2
 pyroma = 2.4
 readme-renderer = 24.0
 requests-toolbelt = 0.8.0
+pbr = 5.1.1
+testfixtures = 4.13.4
+tzlocal = 1.5.1
 
 # Required by:
 # zest.releaser==6.15.0


### PR DESCRIPTION
The reason for these changes is to improve security. The way this works now is, Plone will give its standard error when someone enters an invalid password:

![image](https://user-images.githubusercontent.com/851006/48583610-516d6700-e906-11e8-9fdc-3b9e58be30c7.png)

If you enter your pw several times wrong and your account gets locked, and now you enter your password correctly, the error changes:

![image](https://user-images.githubusercontent.com/851006/48583680-7eba1500-e906-11e8-9954-ab1bd6f6dfbc.png)

This allows for an attacker to use brute force and find the actual password for a user.

This PR solves this by standarizing the same error message, wether the password is incorrect or the user was locked:

![image](https://user-images.githubusercontent.com/851006/48583848-f4be7c00-e906-11e8-91a2-5a11caeaebf2.png)
